### PR TITLE
BanditPAM `v4.0.1`

### DIFF
--- a/.github/workflows/build_linux_wheels.yml
+++ b/.github/workflows/build_linux_wheels.yml
@@ -50,6 +50,8 @@ jobs:
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.12.0
+        env:
+          CIBW_BUILD_VERBOSITY: 3
 
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/build_mac_wheels.yml
+++ b/.github/workflows/build_mac_wheels.yml
@@ -24,6 +24,7 @@ jobs:
         env:
           CIBW_ARCHS_MACOS: x86_64 arm64 universal2
           CIBW_BUILD: cp*
+          CIBW_BUILD_VERBOSITY: 3
 
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/run_cmake_build.yml
+++ b/.github/workflows/run_cmake_build.yml
@@ -50,7 +50,7 @@ jobs:
           export DYLD_LIBRARY_PATH=/usr/local/opt/libomp/lib:/usr/local/opt/libomp/include
           export CC=/usr/local/opt/llvm/bin/clang
           export CXX=/usr/local/opt/llvm/bin/clang++
-          git clone https://github.com/ThrunGroup/BanditPAM
+          git clone https://github.com/motiwari/BanditPAM
           cd BanditPAM
           mkdir build
           cd build

--- a/.github/workflows/run_cmake_build.yml
+++ b/.github/workflows/run_cmake_build.yml
@@ -50,7 +50,7 @@ jobs:
           export DYLD_LIBRARY_PATH=/usr/local/opt/libomp/lib:/usr/local/opt/libomp/include
           export CC=/usr/local/opt/llvm/bin/clang
           export CXX=/usr/local/opt/llvm/bin/clang++
-          git clone https://github.com/motiwari/BanditPAM
+          git clone -b ${GITHUB_REF#refs/heads/} https://github.com/motiwari/BanditPAM
           cd BanditPAM
           mkdir build
           cd build

--- a/.github/workflows/run_linux_tests.yml
+++ b/.github/workflows/run_linux_tests.yml
@@ -27,6 +27,14 @@ jobs:
           pip install pytest
           pip install -r requirements.txt
 
+      - name: Extract branch name
+        shell: bash
+        run: |
+          echo "here";
+          echo ${GITHUB_REF#refs/heads/};
+          echo "here2";
+        id: extract_branch
+
       - name: Install Armadillo 10.7.5+
         run: |
           cd ~
@@ -74,16 +82,7 @@ jobs:
 
       # - name: Run larger suite of test cases
       #   run : |
-      #     pytest tests/test_larger.py 
-
-      - name: Extract branch name
-        shell: bash
-        run: |
-          echo "here";
-          echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})";
-          echo "${{ steps.extract_branch.outputs.branch }}";
-          echo "here2";
-        id: extract_branch
+      #     pytest tests/test_larger.py
 
       - name: Verify that the C++ executable compiles and runs
         run : |

--- a/.github/workflows/run_linux_tests.yml
+++ b/.github/workflows/run_linux_tests.yml
@@ -27,14 +27,6 @@ jobs:
           pip install pytest
           pip install -r requirements.txt
 
-      - name: Extract branch name
-        shell: bash
-        run: |
-          echo "here";
-          echo ${GITHUB_REF#refs/heads/};
-          echo "here2";
-        id: extract_branch
-
       - name: Install Armadillo 10.7.5+
         run: |
           cd ~

--- a/.github/workflows/run_linux_tests.yml
+++ b/.github/workflows/run_linux_tests.yml
@@ -78,7 +78,7 @@ jobs:
 
       - name: Verify that the C++ executable compiles and runs
         run : |
-          git clone https://github.com/ThrunGroup/BanditPAM
+          git clone https://github.com/motiwari/BanditPAM
           cd BanditPAM
           mkdir build
           cd build

--- a/.github/workflows/run_linux_tests.yml
+++ b/.github/workflows/run_linux_tests.yml
@@ -76,6 +76,15 @@ jobs:
       #   run : |
       #     pytest tests/test_larger.py 
 
+      - name: Extract branch name
+        shell: bash
+        run: |
+          echo "here";
+          echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})";
+          echo "${{ steps.extract_branch.outputs.branch }}";
+          echo "here2";
+        id: extract_branch
+
       - name: Verify that the C++ executable compiles and runs
         run : |
           git clone https://github.com/motiwari/BanditPAM

--- a/.github/workflows/run_linux_tests.yml
+++ b/.github/workflows/run_linux_tests.yml
@@ -86,7 +86,7 @@ jobs:
 
       - name: Verify that the C++ executable compiles and runs
         run : |
-          git clone https://github.com/motiwari/BanditPAM
+          git clone -b ${GITHUB_REF#refs/heads/} https://github.com/motiwari/BanditPAM
           cd BanditPAM
           mkdir build
           cd build

--- a/.github/workflows/run_style_checks.yml
+++ b/.github/workflows/run_style_checks.yml
@@ -34,4 +34,4 @@ jobs:
 
       - name: Lint with cpplint
         run: |
-          cpplint --exclude=headers/carma --exclude=build --filter=-legal/copyright,-build/c++11,-build/include_subdir --recursive .
+          cpplint --exclude=headers/carma --exclude=build --exclude=R_package --filter=-legal/copyright,-build/c++11,-build/include_subdir --recursive .

--- a/.github/workflows/run_windows_tests.yml
+++ b/.github/workflows/run_windows_tests.yml
@@ -69,7 +69,7 @@ jobs:
       #     pytest tests/test_larger.py 
       # - name: Verify that the C++ executable compiles and runs
       #   run : |
-      #     git clone https://github.com/motiwari/BanditPAM
+      #     git clone -b ${GITHUB_REF#refs/heads/} https://github.com/motiwari/BanditPAM
       #     cd BanditPAM
       #     mkdir build
       #     cd build

--- a/.github/workflows/run_windows_tests.yml
+++ b/.github/workflows/run_windows_tests.yml
@@ -69,7 +69,7 @@ jobs:
       #     pytest tests/test_larger.py 
       # - name: Verify that the C++ executable compiles and runs
       #   run : |
-      #     git clone https://github.com/ThrunGroup/BanditPAM
+      #     git clone https://github.com/motiwari/BanditPAM
       #     cd BanditPAM
       #     mkdir build
       #     cd build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.17)
 project(BanditPAM VERSION 1.0 LANGUAGES CXX)
 
 # TODO(@motiwari): Should RELEASE? be in caps
-set(CMAKE_BUILD_TYPE Debug)
+set(CMAKE_BUILD_TYPE Release)
 set(CMAKE_CXX_STANDARD 17)
 
 set(CMAKE_CXX_FLAGS_RELEASE "-O3")

--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # BanditPAM: Almost Linear-Time *k*-Medoids Clustering
 
+[![Linux - build package and run tests](https://github.com/motiwari/BanditPAM/actions/workflows/run_linux_tests.yml/badge.svg?branch=main)](https://github.com/motiwari/BanditPAM/actions/workflows/run_linux_tests.yml)
+[![Linux - build source distribution and wheels](https://github.com/motiwari/BanditPAM/actions/workflows/build_linux_wheels.yml/badge.svg)](https://github.com/motiwari/BanditPAM/actions/workflows/build_linux_wheels.yml)
+[![MacOS - build package and run tests](https://github.com/motiwari/BanditPAM/actions/workflows/run_mac_tests.yml/badge.svg)](https://github.com/motiwari/BanditPAM/actions/workflows/run_mac_tests.yml)
+[![MacOS - build wheels](https://github.com/motiwari/BanditPAM/actions/workflows/build_mac_wheels.yml/badge.svg)](https://github.com/motiwari/BanditPAM/actions/workflows/build_mac_wheels.yml)
+[![Run CMake build on MacOS](https://github.com/motiwari/BanditPAM/actions/workflows/run_cmake_build.yml/badge.svg)](https://github.com/motiwari/BanditPAM/actions/workflows/run_cmake_build.yml)
+[![Run style checks](https://github.com/motiwari/BanditPAM/actions/workflows/run_style_checks.yml/badge.svg)](https://github.com/motiwari/BanditPAM/actions/workflows/run_style_checks.yml)
+
 This repo contains a high-performance implementation of BanditPAM from [BanditPAM: Almost Linear-Time k-Medoids Clustering](https://proceedings.neurips.cc/paper/2020/file/73b817090081cef1bca77232f4532c5d-Paper.pdf). The code can be called directly from Python or C++.
 
 If you use this software, please cite:

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Run CMake build on MacOS](https://github.com/motiwari/BanditPAM/actions/workflows/run_cmake_build.yml/badge.svg)](https://github.com/motiwari/BanditPAM/actions/workflows/run_cmake_build.yml)
 [![Run style checks](https://github.com/motiwari/BanditPAM/actions/workflows/run_style_checks.yml/badge.svg)](https://github.com/motiwari/BanditPAM/actions/workflows/run_style_checks.yml)
 
-This repo contains a high-performance implementation of BanditPAM from [BanditPAM: Almost Linear-Time $k$-Medoids Clustering](https://proceedings.neurips.cc/paper/2020/file/73b817090081cef1bca77232f4532c5d-Paper.pdf). The code can be called directly from Python or C++.
+This repo contains a high-performance implementation of BanditPAM from [BanditPAM: Almost Linear-Time k-Medoids Clustering](https://proceedings.neurips.cc/paper/2020/file/73b817090081cef1bca77232f4532c5d-Paper.pdf). The code can be called directly from Python or C++.
 
 If you use this software, please cite:
 
@@ -154,7 +154,7 @@ If installing these requirements from source, one can generally use the followin
 /armadillo/build$ cmake .. && make && sudo make install
 ```
 
-Note that `CARMA` has different installation instructions; see the [its instructions](https://github.com/RUrlus/carma#installation).
+Note that `CARMA` has different installation instructions; see [its instructions](https://github.com/RUrlus/carma#installation).
 
 ####  Platform-specific installation guides
 Further installation information for [MacOS](docs/install_mac.md), [Linux](docs/install_linux.md), and [Windows](docs/install_windows.md) is available in the [docs folder](docs). Ensure all the requirements above are installed and then run:
@@ -189,11 +189,11 @@ Medoids: 694,168,306,714,324,959,527,251,800,737
 
 ## Implementing a custom distance metric
 
-One of the advantages of k-medoids is that it works with arbitrary distance metrics; in fact, your "metric" need not even be a real metric -- it can be negative, asymmetric, and/or not satisfy the triangle inequality or homogeneity. Any pairwise dissimilarity function works with k-medoids!
+One of the advantages of $k$-medoids is that it works with arbitrary distance metrics; in fact, your "metric" need not even be a real metric -- it can be negative, asymmetric, and/or not satisfy the triangle inequality or homogeneity. Any pairwise dissimilarity function works with $k$-medoids.
 
-This also allows for clustering of "exotic" objects like trees, graphs, natural language, and more -- settings where running k-means wouldn't even make sense. We talk about one such setting in the [full paper](https://proceedings.neurips.cc/paper/2020/file/73b817090081cef1bca77232f4532c5d-Paper.pdf).
+This also allows for clustering of "exotic" objects like trees, graphs, natural language, and more -- settings where running $k$-means wouldn't even make sense. We talk about one such setting in the [full paper](https://proceedings.neurips.cc/paper/2020/file/73b817090081cef1bca77232f4532c5d-Paper.pdf).
 
-The package currently supports a number of distance metrics, including all Lp losses and cosine distance.
+The package currently supports a number of distance metrics, including all $L_p$ losses and cosine distance.
 
 If you're willing to write a little C++, you only need to add a few lines to [kmedoids_algorithm.cpp](https://github.com/motiwari/BanditPAM/blob/main/src/kmedoids_algorithm.cpp#L560-L615) and [kmedoids_algorithm.hpp](https://github.com/motiwari/BanditPAM/blob/main/headers/kmedoids_algorithm.hpp#L136-L142) to implement your distance metric / pairwise dissimilarity!
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# BanditPAM: Almost Linear-Time *k*-Medoids Clustering
+# BanditPAM: Almost Linear-Time $k$-Medoids Clustering
 
 [![Linux - build package and run tests](https://github.com/motiwari/BanditPAM/actions/workflows/run_linux_tests.yml/badge.svg?branch=main)](https://github.com/motiwari/BanditPAM/actions/workflows/run_linux_tests.yml)
 [![Linux - build source distribution and wheels](https://github.com/motiwari/BanditPAM/actions/workflows/build_linux_wheels.yml/badge.svg)](https://github.com/motiwari/BanditPAM/actions/workflows/build_linux_wheels.yml)
@@ -7,7 +7,7 @@
 [![Run CMake build on MacOS](https://github.com/motiwari/BanditPAM/actions/workflows/run_cmake_build.yml/badge.svg)](https://github.com/motiwari/BanditPAM/actions/workflows/run_cmake_build.yml)
 [![Run style checks](https://github.com/motiwari/BanditPAM/actions/workflows/run_style_checks.yml/badge.svg)](https://github.com/motiwari/BanditPAM/actions/workflows/run_style_checks.yml)
 
-This repo contains a high-performance implementation of BanditPAM from [BanditPAM: Almost Linear-Time k-Medoids Clustering](https://proceedings.neurips.cc/paper/2020/file/73b817090081cef1bca77232f4532c5d-Paper.pdf). The code can be called directly from Python or C++.
+This repo contains a high-performance implementation of BanditPAM from [BanditPAM: Almost Linear-Time $k$-Medoids Clustering](https://proceedings.neurips.cc/paper/2020/file/73b817090081cef1bca77232f4532c5d-Paper.pdf). The code can be called directly from Python or C++.
 
 If you use this software, please cite:
 
@@ -24,15 +24,15 @@ Mo Tiwari, Martin Jinye Zhang, James Mayclin, Sebastian Thrun, Chris Piech, Ilan
 ```
 
 # Requirements
-# TL;DR run `pip install banditpam` and jump to the [examples](https://github.com/ThrunGroup/BanditPAM#example-1-synthetic-data-from-a-gaussian-mixture-model). 
+# TL;DR run `pip install banditpam` and jump to the [examples](https://github.com/motiwari/BanditPAM#example-1-synthetic-data-from-a-gaussian-mixture-model). 
 
-If you have any difficulties, please see the [platform-specific guides](https://github.com/ThrunGroup/BanditPAM#platform-specific-installation-guides) and file a Github issue if you have additional trouble.
+If you have any difficulties, please see the [platform-specific guides](https://github.com/motiwari/BanditPAM#platform-specific-installation-guides) and file a Github issue if you have additional trouble.
 
 ## Further Reading
 * [Full paper](https://proceedings.neurips.cc/paper/2020/file/73b817090081cef1bca77232f4532c5d-Paper.pdf)
 * [3-minute summary video](https://crossminds.ai/video/bandit-pam-almost-linear-time-k-medoids-clustering-via-multi-armed-bandits-5fb88782b0a3f6412973b646/)
 * [Blog post](https://ai.stanford.edu/blog/banditpam/)
-* [Code](https://github.com/ThrunGroup/BanditPAM)
+* [Code](https://github.com/motiwari/BanditPAM)
 * [PyPI](https://pypi.org/project/banditpam/)
 * [Documentation](https://banditpam.readthedocs.io/en/latest)
 
@@ -116,7 +116,7 @@ plt.show()
 
 ## Documentation
 
-Documentation for BanditPAM can be found on [read the docs](https://banditpam.readthedocs.io/en)
+Documentation for BanditPAM can be found on [read the docs](https://banditpam.readthedocs.io/).
 
 ## Building the C++ executable from source
 
@@ -154,7 +154,7 @@ If installing these requirements from source, one can generally use the followin
 /armadillo/build$ cmake .. && make && sudo make install
 ```
 
-Note that `CARMA` has different installation instructions; see the [quickstart](https://github.com/ThrunGroup/BanditPAM#install-the-repo-and-its-dependencies).
+Note that `CARMA` has different installation instructions; see the [its instructions](https://github.com/RUrlus/carma#installation).
 
 ####  Platform-specific installation guides
 Further installation information for [MacOS](docs/install_mac.md), [Linux](docs/install_linux.md), and [Windows](docs/install_windows.md) is available in the [docs folder](docs). Ensure all the requirements above are installed and then run:
@@ -195,11 +195,11 @@ This also allows for clustering of "exotic" objects like trees, graphs, natural 
 
 The package currently supports a number of distance metrics, including all Lp losses and cosine distance.
 
-If you're willing to write a little C++, you only need to add a few lines to [kmedoids_algorithm.cpp](https://github.com/ThrunGroup/BanditPAM/blob/main/src/kmedoids_algorithm.cpp#L560-L615) and [kmedoids_algorithm.hpp](https://github.com/ThrunGroup/BanditPAM/blob/main/headers/kmedoids_algorithm.hpp#L136-L142) to implement your distance metric / pairwise dissimilarity!
+If you're willing to write a little C++, you only need to add a few lines to [kmedoids_algorithm.cpp](https://github.com/motiwari/BanditPAM/blob/main/src/kmedoids_algorithm.cpp#L560-L615) and [kmedoids_algorithm.hpp](https://github.com/motiwari/BanditPAM/blob/main/headers/kmedoids_algorithm.hpp#L136-L142) to implement your distance metric / pairwise dissimilarity!
 
 Then, be sure to re-install the repository with a `pip install .` (note the trailing `.`).
 
-The maintainers of this repository are working on permitting arbitrary dissimilarity metrics that users write in Python, as well; see [#4](https://github.com/ThrunGroup/BanditPAM/issues/4).
+The maintainers of this repository are working on permitting arbitrary dissimilarity metrics that users write in Python, as well; see [#4](https://github.com/motiwari/BanditPAM/issues/4).
 
 ## Testing
 

--- a/docs/install_linux.md
+++ b/docs/install_linux.md
@@ -9,7 +9,7 @@ Please ensure the following dependencies are installed:
  - `CMake`: via the [CMake installation instructions](https://cmake.org/install/)
  - OpenMP: via `sudo apt install libomp-dev` or `sudo yum install libomp-dev`
  - Armadillo: via the [Armadillo installation instructions](http://arma.sourceforge.net/download.html)
- - CARMA: via the instructions in the [quickstart](https://github.com/ThrunGroup/BanditPAM#install-the-repo-and-its-dependencies)
+ - CARMA: via the instructions in [its guide](https://github.com/RUrlus/carma#installation)
  - Python3: if not installed, we recommend installing Python3 via [Anaconda](https://www.anaconda.com/products/individual), which is CPython compiled with `clang`
  - `pip` for your Python3 installation: this should be completed if installing via Anaconda above
  - The necessary python packages: via `pip install -r requirements.txt`
@@ -34,6 +34,6 @@ BanditPAM can then be installed via one of the following ways:
 2) Running `pip install .` in the home directory (`/BanditPAM`)
 
 ## Known Issues 
-The following is a list of issues seen when installing BanditPAM on Linux. To report a bug, please file an issue at https://github.com/ThrunGroup/BanditPAM/
+The following is a list of issues seen when installing BanditPAM on Linux. To report a bug, please file an issue at https://github.com/motiwari/BanditPAM/
 
 - Beware that installing `libarmadillo-dev` using `apt` or `yum` may provide an outdated version of `armadillo`, especially if you are running an older version of Linux. In this case, you may need to download the latest stable version of `armadillo` and compile it from source

--- a/docs/install_mac.md
+++ b/docs/install_mac.md
@@ -4,11 +4,11 @@ The following is a more detailed description of the installation process of Band
 
 ## Prerequisites
 Please ensure the following dependencies are installed:
- - The most recent version of the Xcode Command Line Tools: via `xcode-select --install`. If you get errors about C++ standard library headers not being found, see the [known issues](https://github.com/ThrunGroup/BanditPAM/blob/main/docs/install_mac.md#known-issues)
+ - The most recent version of the Xcode Command Line Tools: via `xcode-select --install`. If you get errors about C++ standard library headers not being found, see the [known issues](https://github.com/motiwari/BanditPAM/blob/main/docs/install_mac.md#known-issues)
  - Homebrew: via `/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"`
  - LLVM's `clang`: via `brew install llvm`
  - The OpenMP and and Armadillo libraries: via `brew install libomp armadillo`
- - CARMA: via the instructions in the [quickstart](https://github.com/ThrunGroup/BanditPAM#install-the-repo-and-its-dependencies)
+ - CARMA: via the instructions in [its guide](https://github.com/RUrlus/carma#installation)
  - Python3: if not installed, we recommend installing Python3 via [Anaconda](https://www.anaconda.com/products/individual), which is CPython compiled with `clang`
  - `pip` for your Python3 installation; this should be completed if installing via Anaconda above
  - The necessary python packages: via `pip install -r requirements.txt`
@@ -33,9 +33,9 @@ BanditPAM can then be installed via one of the following ways:
 2) Running `pip install .` in the home directory (`/BanditPAM`)
 
 ## Known Issues 
-The following is a list of issues seen when installing BanditPAM on MacOS. To report a bug, please file an issue at https://github.com/ThrunGroup/BanditPAM/
+The following is a list of issues seen when installing BanditPAM on MacOS. To report a bug, please file an issue at https://github.com/motiwari/BanditPAM/
 
-- MacOS users may get an error like the one below. If so, you likely need to update your Xcode Tools. Open the XCode app and install the additional software when prompted. If that still does not work, delete your XCode command line tools, re-install them, open the Xcode app and install the additional software when prompted. If that still does not work, restart your computer and try again. [Original Thread](https://github.com/ThrunGroup/BanditPAM/issues/167#issuecomment-1002747153)
+- MacOS users may get an error like the one below. If so, you likely need to update your Xcode Tools. Open the XCode app and install the additional software when prompted. If that still does not work, delete your XCode command line tools, re-install them, open the Xcode app and install the additional software when prompted. If that still does not work, restart your computer and try again. [Original Thread](https://github.com/motiwari/BanditPAM/issues/167#issuecomment-1002747153)
 
 ```
 /usr/local/opt/llvm/bin/../include/c++/v1/stdlib.h:93:15: fatal error: 'stdlib.h' file not found
@@ -44,4 +44,4 @@ The following is a list of issues seen when installing BanditPAM on MacOS. To re
 1 error generated.
 error: command '/usr/local/opt/llvm/bin/clang' failed with exit code 1
 ```
-- Building the wheels for PyPy on MacOS via `cibuildwheel` do not work. As such, it's necessary to build the package from source if using PyPy. For more information, see the [Developer Notes](https://github.com/ThrunGroup/BanditPAM/wiki/Developer-Notes)
+- Building the wheels for PyPy on MacOS via `cibuildwheel` do not work. As such, it's necessary to build the package from source if using PyPy. For more information, see the [Developer Notes](https://github.com/motiwari/BanditPAM/wiki/Developer-Notes)

--- a/docs/install_windows.md
+++ b/docs/install_windows.md
@@ -8,7 +8,7 @@ Please ensure the following dependencies are installed:
  - OpenMP: if using LLVM's `clang`, then OpenMP is already enabled
  - `CMake`: via the [CMake installation instructions](https://cmake.org/install/)
  - Armadillo: via the [Armadillo installation instructions](http://arma.sourceforge.net/download.html)
- - CARMA: via the instructions in the [quickstart](https://github.com/ThrunGroup/BanditPAM#install-the-repo-and-its-dependencies)
+ - CARMA: via the instructions in [its guide](https://github.com/RUrlus/carma#installation)
  - Python3: if not installed, we recommend installing Python3 via [Anaconda](https://www.anaconda.com/products/individual), which is CPython compiled with `clang`
  - `pip` for your Python3 installation: this should be completed if installing via Anaconda above
  - The necessary python packages: via `pip install -r requirements.txt`
@@ -33,6 +33,6 @@ BanditPAM can then be installed via one of the following ways:
 2) Running `pip install .` in the home directory (`/BanditPAM`)
 
 ## Known Issues 
-The following is a list of issues seen when installing BanditPAM on Windows. To report a bug, please file an issue at https://github.com/ThrunGroup/BanditPAM/
+The following is a list of issues seen when installing BanditPAM on Windows. To report a bug, please file an issue at https://github.com/motiwari/BanditPAM/
 
-- You may run into an error like `error: ‘class arma::Mat<float>’ has no member named ‘n_alloc’`; this is fundamentally due to an [error in CARMA](https://github.com/RUrlus/carma/pull/98). If this isn't fixed by the time you're reading this, follow the fix described in [this issue](https://github.com/ThrunGroup/BanditPAM/issues/169).
+- You may run into an error like `error: ‘class arma::Mat<float>’ has no member named ‘n_alloc’`; this is fundamentally due to an [error in CARMA](https://github.com/RUrlus/carma/pull/98). If this isn't fixed by the time you're reading this, follow the fix described in [this issue](https://github.com/motiwari/BanditPAM/issues/169).

--- a/docs/long_desc.rst
+++ b/docs/long_desc.rst
@@ -4,7 +4,7 @@ BanditPAM: A state-of-the-art, high-performance k-medoids algorithm
 Quickstart
 ----------
 
-Run `pip install banditpam` and then check out the `examples <https://github.com/ThrunGroup/BanditPAM#example-1-synthetic-data-from-a-gaussian-mixture-model>`_.
+Run `pip install banditpam` and then check out the `examples <https://github.com/motiwari/BanditPAM#example-1-synthetic-data-from-a-gaussian-mixture-model>`_.
 
 If you use this software, please cite:
 Mo Tiwari, Martin Jinye Zhang, James Mayclin, Sebastian Thrun, Chris Piech, Ilan Shomorony. "BanditPAM: Almost Linear Time k-medoids Clustering via Multi-Armed Bandits" Advances in Neural Information Processing Systems (NeurIPS) 2020.
@@ -37,6 +37,6 @@ Further Reading
 * `Full paper <https://proceedings.neurips.cc/paper/2020/file/73b817090081cef1bca77232f4532c5d-Paper.pdf>`_
 * `3-minute summary video <https://crossminds.ai/video/bandit-pam-almost-linear-time-k-medoids-clustering-via-multi-armed-bandits-5fb88782b0a3f6412973b646/>`_
 * `Blog post <https://ai.stanford.edu/blog/banditpam/>`_
-* `Code <https://github.com/ThrunGroup/BanditPAM>`_
+* `Code <https://github.com/motiwari/BanditPAM>`_
 * `PyPI <https://pypi.org/project/banditpam/>`_
 * `Documentation <https://banditpam.readthedocs.io/en>`_

--- a/headers/algorithms/kmedoids_algorithm.hpp
+++ b/headers/algorithms/kmedoids_algorithm.hpp
@@ -321,7 +321,7 @@ class KMedoids {
   float getTimePerSwap() const;
 
   /// The cache which stores pairwise distance computations
-  std::vector<float> cache;
+  float* cache;
 
   /// The permutation in which to sample the reference points
   arma::uvec permutation;

--- a/headers/algorithms/kmedoids_algorithm.hpp
+++ b/headers/algorithms/kmedoids_algorithm.hpp
@@ -33,7 +33,7 @@ class KMedoids {
     const std::string& algorithm = "BanditPAM",
     size_t maxIter = 100,
     size_t buildConfidence = 3,
-    size_t swapConfidence = 4,
+    size_t swapConfidence = 5,
     bool useCache = true,
     bool usePerm = true,
     size_t cacheWidth = 1000,

--- a/headers/algorithms/kmedoids_algorithm.hpp
+++ b/headers/algorithms/kmedoids_algorithm.hpp
@@ -321,7 +321,7 @@ class KMedoids {
   float getTimePerSwap() const;
 
   /// The cache which stores pairwise distance computations
-  float* cache;
+  std::vector<float> cache;
 
   /// The permutation in which to sample the reference points
   arma::uvec permutation;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,8 +24,9 @@ before-all = [
 
 # Adding /usr/local/lib because that's where armadillo is installed from the repo
 repair-wheel-command = [
+    "DYLD_LIBRARY_PATH=/usr/local/Cellar/armadillo/10.8.1/lib:/usr/local/opt/armadillo/lib:/usr/local/lib:/usr/local/opt/libomp/lib:/usr/local/Cellar/libomp/15.0.2/lib:/usr/local/Cellar/libomp/15.0.7/lib delocate-listdeps --depending {wheel}",
     "DYLD_LIBRARY_PATH=/usr/local/Cellar/armadillo/10.8.1/lib:/usr/local/opt/armadillo/lib:/usr/local/lib:/usr/local/opt/libomp/lib:/usr/local/Cellar/libomp/15.0.2/lib:/usr/local/Cellar/libomp/15.0.7/lib delocate-listdeps {wheel}",
-    "DYLD_LIBRARY_PATH=/usr/local/Cellar/armadillo/10.8.1/lib:/usr/local/opt/armadillo/lib:/usr/local/lib:/usr/local/opt/libomp/lib:/usr/local/Cellar/libomp/15.0.2/lib:/usr/local/Cellar/libomp/15.0.7/lib -w {dest_dir} {wheel}"
+    "DYLD_LIBRARY_PATH=/usr/local/Cellar/armadillo/10.8.1/lib:/usr/local/opt/armadillo/lib:/usr/local/lib:/usr/local/opt/libomp/lib:/usr/local/Cellar/libomp/15.0.2/lib:/usr/local/Cellar/libomp/15.0.7/lib delocate-wheel -v -w {dest_dir} {wheel}"
 ]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,9 +21,11 @@ before-all = [
 #    "DYLD_LIBRARY_PATH=/usr/local/Cellar/armadillo/10.8.1/lib delocate-listdeps {wheel}",
 #    "DYLD_LIBRARY_PATH=/usr/local/Cellar/armadillo/10.8.1/lib delocate-wheel --require-archs {delocate_archs} -w {dest_dir} {wheel}"
 #]
+
+# Adding /usr/local/lib because that's where armadillo is installed from the repo
 repair-wheel-command = [
-    "DYLD_LIBRARY_PATH=/usr/local/Cellar/armadillo/10.8.1/lib:/usr/local/opt/armadillo/lib delocate-listdeps {wheel}",
-    "DYLD_LIBRARY_PATH=/usr/local/Cellar/armadillo/10.8.1/lib:/usr/local/opt/armadillo/lib delocate-wheel -w {dest_dir} {wheel}"
+    "DYLD_LIBRARY_PATH=/usr/local/Cellar/armadillo/10.8.1/lib:/usr/local/opt/armadillo/lib:/usr/local/lib:/usr/local/opt/libomp/lib:/usr/local/Cellar/libomp/15.0.2/lib:/usr/local/Cellar/libomp/15.0.7/lib delocate-listdeps {wheel}",
+    "DYLD_LIBRARY_PATH=/usr/local/Cellar/armadillo/10.8.1/lib:/usr/local/opt/armadillo/lib:/usr/local/lib:/usr/local/opt/libomp/lib:/usr/local/Cellar/libomp/15.0.2/lib:/usr/local/Cellar/libomp/15.0.7/lib -w {dest_dir} {wheel}"
 ]
 
 

--- a/scripts/colab_files/colab_setup.sh
+++ b/scripts/colab_files/colab_setup.sh
@@ -10,7 +10,7 @@ tar -xvzf cmake-v3.22.1.tar.gz
 cd /content/CMake-3.22.1 && mkdir build && cd build && cmake .. && make && make install
 
 cd /content
-git clone https://github.com/ThrunGroup/BanditPAM.git
+git clone https://github.com/motiwari/BanditPAM.git
 cd /content/BanditPAM
 git submodule update --init --recursive
 cd /content/BanditPAM/headers/carma

--- a/setup.py
+++ b/setup.py
@@ -259,7 +259,7 @@ def setup_colab(delete_source=False):
         repo_location = os.path.join("/", "content", "BanditPAM")
         # Note the space after the git URL to separate the source and target
         os.system(
-            "git clone https://github.com/ThrunGroup/BanditPAM.git "
+            "git clone https://github.com/motiwari/BanditPAM.git "
             + repo_location
         )
         os.system(
@@ -523,7 +523,7 @@ def main():
         author="Mo Tiwari",
         maintainer="Mo Tiwari",
         author_email="motiwari@stanford.edu",
-        url="https://github.com/ThrunGroup/BanditPAM",
+        url="https://github.com/motiwari/BanditPAM",
         description="BanditPAM: A state-of-the-art, \
             high-performance k-medoids algorithm.",
         long_description=long_description,

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools.command.build_ext import build_ext
 import distutils.sysconfig
 import distutils.spawn
 
-__version__ = "4.0.0"
+__version__ = "4.0.1"
 
 # TODO(@motiwari): Move this to a separate file
 GHA = "GITHUB_ACTIONS"

--- a/setup.py
+++ b/setup.py
@@ -387,7 +387,7 @@ class BuildExt(build_ext):
         if (sys.platform == "darwin" and os.environ.get(GHA, False)):
             link_opts.append('-lomp')  # Potentially unused?
             link_opts.append('-I/usr/local/opt/libomp/include')
-            link_opts.append('-L/usr/local/opt/libomp/lib')  # Potentially unused?
+            link_opts.append('-L/usr/local/opt/libomp/lib')  # Unused?
         else:
             if compiler_name == "clang":
                 link_opts.append("-lomp")
@@ -465,7 +465,8 @@ def main():
 
     compiler_name = compiler_check()
     if (sys.platform == "darwin" and os.environ.get(GHA, False)):
-        # On Mac Github Runners, we should NOT include gomp or omp here due to build errors.
+        # On Mac Github Runners, we should NOT include gomp or omp here
+        # due to build errors.
         libraries = ["armadillo", "omp"]
     else:
         if compiler_name == "clang":
@@ -498,8 +499,8 @@ def main():
             include_dirs=include_dirs,
             library_dirs=[
                 os.path.join("/", "usr", "local", "lib"),
-                # For Mac Github runners that install locally (not build wheels) - testing
-                # for macos-10.15
+                # For Mac Github runners that install locally
+                # (not build wheels) - testing for macos-10.15
                 os.path.join("/", "usr", "local", "Cellar", "libomp",
                              "15.0.2", "lib"),
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -8,6 +8,7 @@ include_directories(${PROJECT_SOURCE_DIR}/headers/carma/include/carma_bits)
 include_directories(/usr/local/Cellar/libomp/15.0.2/include)
 include_directories(/usr/local/Cellar/libomp/15.0.7/include)
 include_directories(/usr/local/Cellar/libomp)
+include_directories(/usr/local/opt/libomp/lib)
 include_directories(/usr/local/opt/libomp)
 include_directories(/usr/local/opt)
 

--- a/src/algorithms/banditpam.cpp
+++ b/src/algorithms/banditpam.cpp
@@ -25,7 +25,7 @@ void BanditPAM::fitBanditPAM(
   if (this->useCache) {
     size_t n = data.n_cols;
     size_t m = fmin(n, cacheWidth);
-    vector<float> cache(n * m, -1);
+    std::vector<float> cache(n*m, -1);
 
     #pragma omp parallel for if (this->parallelize)
     for (size_t idx = 0; idx < m*n; idx++) {

--- a/src/algorithms/banditpam.cpp
+++ b/src/algorithms/banditpam.cpp
@@ -25,7 +25,7 @@ void BanditPAM::fitBanditPAM(
   if (this->useCache) {
     size_t n = data.n_cols;
     size_t m = fmin(n, cacheWidth);
-    std::vector<float> cache(n*m, -1);
+    cache = new float[n * m];
 
     #pragma omp parallel for if (this->parallelize)
     for (size_t idx = 0; idx < m*n; idx++) {

--- a/src/algorithms/banditpam.cpp
+++ b/src/algorithms/banditpam.cpp
@@ -10,6 +10,7 @@
 #include <armadillo>
 #include <unordered_map>
 #include <cmath>
+#include <vector>
 
 namespace km {
 void BanditPAM::fitBanditPAM(
@@ -24,7 +25,7 @@ void BanditPAM::fitBanditPAM(
   if (this->useCache) {
     size_t n = data.n_cols;
     size_t m = fmin(n, cacheWidth);
-    cache = new float[n * m];
+    vector<float> cache(n * m, -1);
 
     #pragma omp parallel for if (this->parallelize)
     for (size_t idx = 0; idx < m*n; idx++) {

--- a/src/algorithms/banditpam_orig.cpp
+++ b/src/algorithms/banditpam_orig.cpp
@@ -25,7 +25,7 @@ void BanditPAM_orig::fitBanditPAM_orig(
   if (this->useCache) {
     size_t n = data.n_cols;
     size_t m = fmin(n, cacheWidth);
-    vector<float> cache(n * m, -1);
+    std::vector<float> cache(n*m, -1);
 
     #pragma omp parallel for if (this->parallelize)
     for (size_t idx = 0; idx < m*n; idx++) {

--- a/src/algorithms/banditpam_orig.cpp
+++ b/src/algorithms/banditpam_orig.cpp
@@ -10,6 +10,7 @@
 #include <armadillo>
 #include <unordered_map>
 #include <cmath>
+#include <vector>
 
 namespace km {
 void BanditPAM_orig::fitBanditPAM_orig(
@@ -24,7 +25,7 @@ void BanditPAM_orig::fitBanditPAM_orig(
   if (this->useCache) {
     size_t n = data.n_cols;
     size_t m = fmin(n, cacheWidth);
-    cache = new float[n * m];
+    vector<float> cache(n * m, -1);
 
     #pragma omp parallel for if (this->parallelize)
     for (size_t idx = 0; idx < m*n; idx++) {

--- a/src/algorithms/banditpam_orig.cpp
+++ b/src/algorithms/banditpam_orig.cpp
@@ -25,7 +25,7 @@ void BanditPAM_orig::fitBanditPAM_orig(
   if (this->useCache) {
     size_t n = data.n_cols;
     size_t m = fmin(n, cacheWidth);
-    std::vector<float> cache(n*m, -1);
+    cache = new float[n * m];
 
     #pragma omp parallel for if (this->parallelize)
     for (size_t idx = 0; idx < m*n; idx++) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -23,7 +23,7 @@ int main(int argc, char* argv[]) {
     int prev_ind;
     size_t maxIter = 100;
     size_t buildConfidence = 3;
-    size_t swapConfidence = 4;
+    size_t swapConfidence = 5;
     std::string loss = "L2";
     bool f_flag = false;
     bool k_flag = false;

--- a/src/python_bindings/kmedoids_pywrapper.cpp
+++ b/src/python_bindings/kmedoids_pywrapper.cpp
@@ -40,7 +40,7 @@ PYBIND11_MODULE(banditpam, m) {
     pybind11::arg("algorithm") = "BanditPAM",
     pybind11::arg("max_iter") = 100,
     pybind11::arg("build_confidence") = 3,
-    pybind11::arg("swap_confidence") = 4,
+    pybind11::arg("swap_confidence") = 5,
     // TODO(@motiwari): Verify these options are re-used correctly on reset
     pybind11::arg("use_cache") = true,
     pybind11::arg("use_perm") = true,


### PR DESCRIPTION
BanditPAM `v4.0.1` contains a few minor changes:

**Organization and Functionality:**
- Makes  `cibuildwheel` more verbose
- For CMake builds, checks out the current branch (not `main`) in GHA
- Changes the CMake build to `Release` mode to avoid running sanitizers in GHA
- Adds status badges (Fixes #224)
- Fixes the GHA builds by including the proper directory for `armadillo` (the locally installed version)
 
**Tests:**
No changes.

**Style:**
No changes.

**Documentation:**
- Updates `README.md` and other docs
