### PR TITLE
`v4.0.4`

### DIFF
--- a/.github/workflows/run_windows_tests.yml
+++ b/.github/workflows/run_windows_tests.yml
@@ -1,5 +1,5 @@
 name: Windows - build package and run tests
-on: [push, pull_request] # This test is currently disabled until we can build Armadillo on Windows
+on: [push, pull_request]
 jobs:
   build:
     runs-on: windows-latest
@@ -13,45 +13,19 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-      # - name: Install Windows dependencies
-      #   run: |
-      #     cmake --version
-      # - name: Install CPython from Anaconda # TODO: Need to update CMake? # TODO: See https://docs.conda.io/projects/conda/en/latest/user-guide/install/windows.html
-      #   run: |
-      #     curl -XGET https://repo.anaconda.com/archive/Anaconda3-2021.11-Windows-x86_64.exe > Anaconda3-2021.11-Windows-x86_64.exe
-      #     start /wait "" "Anaconda3-latest-Windows-x86_64.exe" /InstallationType=JustMe /AddToPath=1 /RegisterPython=1 /S /D=%UserProfile%\Anaconda3
-      #     conda create -n "$p{{ matrix.python-version }}" python=${{ matrix.python-version }}
-      #     conda activate p${{ matrix.python-version }}
-      - name: Install Python dependencies 
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install pytest
-          python -m pip install -r requirements.txt
-      - name: Install Armadillo 10.7.5+
-        run: |
-          cd ~
-          git clone https://gitlab.com/conradsnicta/armadillo-code.git
-          cd armadillo-code
-          cmake .
-      - name: Install carma
-        run: |
-          cd ~
-          git clone https://github.com/RUrlus/carma.git
-          cd carma
-          mkdir build
-          cd build
-          cmake -DCARMA_INSTALL_LIB=ON ..
-          cmake --build . --config Release --target install
-          cd ~
-      - name: Install BanditPAM package
-        run: |
-          python -m pip install -vvv -e .
-        env:
-          # The default compiler on the Github Ubuntu runners is gcc
-          # Would need to make a respective include change for clang 
-          CPLUS_INCLUDE_PATH: /usr/local/include/carma
+
+      - name: Clone for PR
+        if: ${{ github.event_name == 'pull_request' }}
+        run: git clone -b $env:GITHUB_HEAD_REF https://github.com/motiwari/BanditPAM
+
+      - name: Clone for Push
+        if: ${{ github.event_name != 'pull_request' }}
+        run: git clone -b ($env:GITHUB_REF -replace '^refs/heads/', '') https://github.com/motiwari/BanditPAM
+
       - name: Downloading data files for tests
+        shell: bash
         run: |
+          cd BanditPAM
           mkdir -p data
           curl -XGET https://motiwari.com/banditpam_data/scRNA_1k.csv > data/scRNA_1k.csv
           curl -XGET https://motiwari.com/banditpam_data/scrna_reformat.csv.gz > data/scrna_reformat.csv.gz
@@ -61,18 +35,64 @@ jobs:
           tar -xzvf data/MNIST_10k.tar.gz -C data
           curl -XGET https://motiwari.com/banditpam_data/MNIST_70k.tar.gz > data/MNIST_70k.tar.gz
           tar -xzvf data/MNIST_70k.tar.gz -C data
+
+      - name: Install Armadillo 10.7.5+
+        run: |
+          cd BanditPAM/headers
+          git clone https://gitlab.com/conradsnicta/armadillo-code.git armadillo
+          cd armadillo
+          cmake .
+          C:/"Program Files"/"Microsoft Visual Studio"/2022/Enterprise/Common7/IDE/devenv armadillo.sln /Build "Release|x64"
+
+      - name: Add environment variables
+        run: |
+          Add-Content $env:GITHUB_PATH "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.36.32532\bin\HostX86\x86"
+
+      - name: Install carma
+        run: |
+          cd BanditPAM/headers
+          git clone https://github.com/RUrlus/carma.git
+          cd carma
+          mkdir build
+          cd build
+          cmake -DCARMA_INSTALL_LIB=ON ..
+          cmake --build . --config Release --target install
+          cd ../../..
+
+      - name: Verify that the C++ executable compiles and runs  # Building C++ first to avoid armadillo include issues
+        run: |
+          cd BanditPAM/scripts
+          sh retrieve_windows_cmake_files.sh
+          cd ..
+          mkdir build
+          cd build
+          cmake ..
+          C:/"Program Files"/"Microsoft Visual Studio"/2022/Enterprise/Common7/IDE/devenv BanditPAM.sln /Build "Release|x64"
+          cd src/Release
+          .\BanditPAM.exe -f ../../../data/MNIST_1k.csv -k 5
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements.txt
+          python -m pip install --upgrade pip setuptools wheel
+
+      - name: Install BanditPAM package
+        run: |
+          cd BanditPAM
+          # The flags are necessary to ignore the pyproject.toml
+          # See https://github.com/pypa/pip/issues/9738
+          python -m pip install -vvvv --no-use-pep517 .
+          cd scripts
+          sh retrieve_windows_python_files.sh
+          cd ..
+          python -m pip install -vvvv --no-use-pep517 .
+
       - name: Run smaller suite of test cases
-        run : |
-          pytest tests/test_smaller.py 
+        run: |
+          cd BanditPAM
+          python tests/test_smaller.py
+
       # - name: Run larger suite of test cases
       #   run : |
-      #     pytest tests/test_larger.py 
-      # - name: Verify that the C++ executable compiles and runs
-      #   run : |
-      #     git clone -b ${GITHUB_REF#refs/heads/} https://github.com/motiwari/BanditPAM
-      #     cd BanditPAM
-      #     mkdir build
-      #     cd build
-      #     cmake ..
-      #     make
-      #     src/BanditPAM -f ../data/MNIST_1k.csv -k 5
+      #     python tests/test_larger.py

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,35 @@
+# Read the Docs configuration file for Sphinx projects
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the OS, Python version and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+    # You can also specify other tool versions:
+    # nodejs: "20"
+    # rust: "1.70"
+    # golang: "1.20"
+
+# Build documentation in the "docs/" directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+  # You can configure Sphinx to use a different builder, for instance use the dirhtml builder for simpler URLs
+  # builder: "dirhtml"
+  # Fail on all warnings to avoid broken references
+  # fail_on_warning: true
+
+# Optionally build your docs in additional formats such as PDF and ePub
+# formats:
+#    - pdf
+#    - epub
+
+# Optional but recommended, declare the Python requirements required
+# to build your documentation
+# See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
+# python:
+#    install:
+#    - requirements: docs/requirements.txt

--- a/docs/install_windows.md
+++ b/docs/install_windows.md
@@ -26,5 +26,5 @@ Python Build:
 2) Follow these steps:
    1) Add the location of `cl.exe` to PATH in Environment Variables (e.g. `C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.34.31933\bin\Hostx64\x64`).
    2) Run `python -m pip install .` in the home directory (`/BanditPAM`)
-   2) Add the file `C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.34.31933\bin\Hostx86\x64\clang_rt.asan_dynamic-x86_64.dll` to `build\lib.win-amd64-cpython-310`
-   3) Run `python -m pip install .` in the home directory (`/BanditPAM`)
+   3) Run `cd scripts && sh retrieve_windows_python_files.sh && cd ..`
+   4) Run `python -m pip install .` in the home directory (`/BanditPAM`)

--- a/scripts/retrieve_windows_python_files.sh
+++ b/scripts/retrieve_windows_python_files.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# This script is used to retrieve the files necessary for the Windows Python build
+echo "Retrieving files for Windows Python build..."
+cd ..
+git clone https://github.com/ThrunGroup/BanditPAM_Windows
+cd build
+cd -- "$(find . -name 'lib.*')"
+mv ../../BanditPAM_Windows/clang_rt.asan_dynamic-x86_64.dll clang_rt.asan_dynamic-x86_64.dll
+rm -rf ../../BanditPAM_Windows
+echo "Done!"

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools.command.build_ext import build_ext
 import distutils.sysconfig
 import distutils.spawn
 
-__version__ = "4.0.3"
+__version__ = "4.0.4a0"
 
 # TODO(@motiwari): Move this to a separate file
 GHA = "GITHUB_ACTIONS"

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools.command.build_ext import build_ext
 import distutils.sysconfig
 import distutils.spawn
 
-__version__ = "4.0.4a0"
+__version__ = "4.0.4"
 
 # TODO(@motiwari): Move this to a separate file
 GHA = "GITHUB_ACTIONS"

--- a/tests/test_smaller.py
+++ b/tests/test_smaller.py
@@ -18,7 +18,9 @@ class SmallerTests(unittest.TestCase):
     small_mnist = pd.read_csv("data/MNIST_100.csv", header=None).to_numpy()
     mnist_70k = pd.read_csv("data/MNIST_70k.csv", sep=" ", header=None)
     if sys.platform == "win32":
-        scrna = pd.read_csv("data/scrna_reformat.csv.gz", header=None, dtype='float16')  # float16 for less memory usage
+        scrna = pd.read_csv(
+            "data/scrna_reformat.csv.gz", header=None, dtype="float16"
+        )  # float16 for less memory usage
     else:
         scrna = pd.read_csv("data/scrna_reformat.csv.gz", header=None)
 

--- a/tests/test_smaller.py
+++ b/tests/test_smaller.py
@@ -1,6 +1,7 @@
 import unittest
 import pandas as pd
 import numpy as np
+import sys
 
 from banditpam import KMedoids
 from utils import bpam_agrees_pam
@@ -16,7 +17,10 @@ from constants import (
 class SmallerTests(unittest.TestCase):
     small_mnist = pd.read_csv("data/MNIST_100.csv", header=None).to_numpy()
     mnist_70k = pd.read_csv("data/MNIST_70k.csv", sep=" ", header=None)
-    scrna = pd.read_csv("data/scrna_reformat.csv.gz", header=None)
+    if sys.platform == "win32":
+        scrna = pd.read_csv("data/scrna_reformat.csv.gz", header=None, dtype='float16')  # float16 for less memory usage
+    else:
+        scrna = pd.read_csv("data/scrna_reformat.csv.gz", header=None)
 
     def test_small_mnist(self):
         """


### PR DESCRIPTION
BanditPAM `v4.0.4` contains the following changes:

**Organization and Functionality:**
- Added a new GHA to build the package and run tests on Windows.
- Added a configuration file v2 for our Read the Docs documentation.
- Added a convenience script `retrieve_windows_python_files.sh` to retrieve `clang_rt.asan_dynamic-x86_64.dll` automatically for the Windows Python build.

**Tests:**
- Updated `tests/test_smaller.py` to use different data types on different platforms when loading `data/scrna_reformat.csv.gz` to adjust memory usage.

**Documentation:**
-  Updated the Windows installation instructions to use the convenience script `retrieve_windows_python_files.sh`.
