### PR TITLE
BanditPAM 5.0.0: Fixing all github actions and shipping new wheels

### DIFF
--- a/.github/workflows/linux_build_wheels.yml
+++ b/.github/workflows/linux_build_wheels.yml
@@ -12,7 +12,7 @@ jobs:
     name: Build source distribution (SDist)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: true
 
@@ -22,8 +22,7 @@ jobs:
       - name: Install Ubuntu dependencies
         run: |
           sudo apt update
-          sudo apt install -y build-essential checkinstall libncursesw5-dev libssl-dev libsqlite3-dev tk-dev libgdbm-dev libc6-dev libbz2-dev libffi-dev zlib1g-dev 
-          sudo apt install -y clang-format cppcheck
+          sudo apt install -y build-essential checkinstall libssl-dev libsqlite3-dev tk-dev libgdbm-dev libc6-dev libbz2-dev libffi-dev zlib1g-dev clang-format cppcheck
 
       # See note above
       - name: Install Python dependencies 
@@ -35,8 +34,9 @@ jobs:
       - name: Build sdist
         run: python setup.py sdist --formats=gztar,zip
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
+          name: artifact-sdist
           path: |
             dist/*.tar.gz
             # dist/*.zip # We can only upload one sdist per release
@@ -46,31 +46,35 @@ jobs:
     name: Build wheels on ubuntu-latest
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: true
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.12.0
+        uses: pypa/cibuildwheel@v2.23.2
         env:
+          CIBW_BUILD: cp310* cp311* cp312* cp313*
           CIBW_BUILD_VERBOSITY: 3
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           path: wheelhouse/*.whl
+          name: artifact-${{ matrix.python-version }}-${{ matrix.arch }}
 
   upload_pypi:
     needs: [build_wheels, build_sdist]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v4
         with:
-          name: artifact
+          pattern: artifact-*
           path: dist
+          merge-multiple: true
+
 
       - name: Upload to TestPyPI on PR update
         if: ${{ github.event_name == 'pull_request' }}
-        uses: pypa/gh-action-pypi-publish@v1.4.2
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
           password: ${{ secrets.TEST_PYPI_APIKEY }}
@@ -78,7 +82,7 @@ jobs:
 
       - name: Upload to PyPI on published release
         if: ${{ github.event_name == 'release' && github.event.action == 'published' }}
-        uses: pypa/gh-action-pypi-publish@v1.4.2
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
           password: ${{ secrets.PYPI_APIKEY }}

--- a/.github/workflows/linux_run_tests.yml
+++ b/.github/workflows/linux_run_tests.yml
@@ -1,0 +1,99 @@
+name: Linux - build package and run tests
+on:
+  push:
+    branches:  # prevents running on tag push
+      - '**'
+  pull_request:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5.6.0
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install Ubuntu dependencies
+        run: |
+          sudo apt update
+          sudo apt install -y build-essential checkinstall libssl-dev libsqlite3-dev tk-dev libgdbm-dev libc6-dev libbz2-dev libffi-dev zlib1g-dev 
+          sudo apt install -y clang-format cppcheck
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pytest
+          python -m pip install -r requirements.txt
+          python -m pip install --upgrade pip setuptools wheel
+
+      - name: Install Armadillo 10.7.5+
+        run: |
+          cd ~
+          git clone https://gitlab.com/conradsnicta/armadillo-code.git
+          cd armadillo-code
+          sudo cmake .
+          sudo make install
+
+      - name: Install carma
+        run: |
+          cd ~
+          git clone https://github.com/RUrlus/carma.git
+          cd carma
+          mkdir build
+          cd build
+          sudo cmake -DCARMA_INSTALL_LIB=ON ..
+          sudo cmake --build . --config Release --target install
+          cd ~
+
+      - name: Install BanditPAM package
+        run: |
+          # The flags are necessary to ignore the pyproject.toml
+          # See https://github.com/pypa/pip/issues/9738
+          python -m pip install --no-use-pep517 --no-build-isolation -vvv -e .
+        env:
+          # The default compiler on the Github Ubuntu runners is gcc
+          # Would need to make a respective include change for clang
+          CPLUS_INCLUDE_PATH: /usr/local/include/carma
+
+      - name: Downloading data files for tests
+        run: |
+          mkdir -p data
+          curl -XGET https://motiwari.com/banditpam_data/scRNA_1k.csv > data/scRNA_1k.csv
+          curl -XGET https://motiwari.com/banditpam_data/scrna_reformat.csv.gz > data/scrna_reformat.csv.gz
+          curl -XGET https://motiwari.com/banditpam_data/MNIST_100.csv > data/MNIST_100.csv
+          curl -XGET https://motiwari.com/banditpam_data/MNIST_1k.csv > data/MNIST_1k.csv
+          curl -XGET https://motiwari.com/banditpam_data/MNIST_10k.tar.gz > data/MNIST_10k.tar.gz
+          tar -xzvf data/MNIST_10k.tar.gz -C data
+          curl -XGET https://motiwari.com/banditpam_data/MNIST_70k.tar.gz > data/MNIST_70k.tar.gz
+          tar -xzvf data/MNIST_70k.tar.gz -C data
+
+      - name: Run smaller suite of test cases
+        run : |
+          pytest tests/test_smaller.py 
+
+      - name: Run tests cases for initialization
+        run : |
+          pytest tests/test_initialization.py 
+
+      - name: Clone for PR
+        if: ${{ github.event_name == 'pull_request' }}
+        run: git clone -b $GITHUB_HEAD_REF https://github.com/motiwari/BanditPAM
+
+      - name: Clone for Push
+        if: ${{ github.event_name != 'pull_request' }}
+        run: git clone -b ${GITHUB_REF#refs/heads/} https://github.com/motiwari/BanditPAM
+
+      - name: Verify that the C++ executable compiles and runs
+        run : |
+          cd BanditPAM
+          mkdir build
+          cd build
+          sudo cmake ..
+          sudo make
+          src/BanditPAM -f ../data/MNIST_1k.csv -k 5 -l L2

--- a/.github/workflows/mac_arm64_cmake_build.yml
+++ b/.github/workflows/mac_arm64_cmake_build.yml
@@ -1,4 +1,4 @@
-name: Run CMake build on MacOS
+name: Mac ARM64 - Run CMake Build and Tests
 on:
   push:
     branches:  # prevents running on tag push
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       # On the MacOS machine, when installing from source,
       # we use LLVM Clang
@@ -55,17 +55,17 @@ jobs:
       # TODO(@motiwari): Clean this environment variables up
       - name: Verify that the C++ executable compiles and runs
         run : |
-          echo 'export PATH="/usr/local/opt/llvm/bin:$PATH"' >> /Users/runner/.bash_profile
+          echo 'export PATH="/usr/local/opt/llvm/bin:/opt/homebrew/opt/llvm/bin:$PATH"' >> /Users/runner/.bash_profile
           source /Users/runner/.bash_profile
           export LDFLAGS="-L/usr/local/opt/llvm/lib, -L/usr/local/opt/llvm/lib/c++ -Wl,-rpath,/usr/local/opt/llvm/lib/c++"
           export CPPFLAGS="-I/usr/local/opt/llvm/include"
           export DYLD_LIBRARY_PATH=/usr/local/opt/libomp/lib:/usr/local/opt/libomp/include
-          export CC=/usr/local/opt/llvm/bin/clang
-          export CXX=/usr/local/opt/llvm/bin/clang++
+          export CC=/opt/homebrew/opt/llvm/bin/clang
+          export CXX=/opt/homebrew/opt/llvm/bin/clang++
           cd BanditPAM
           mkdir build
           cd build
-          sudo CC=/usr/local/opt/llvm/bin/clang CXX=/usr/local/opt/llvm/bin/clang++ cmake ..
+          sudo CC=/opt/homebrew/opt/llvm/bin/clang CXX=/opt/homebrew/opt/llvm/bin/clang++ cmake ..
           sudo make
           src/BanditPAM -f ../data/MNIST_1k.csv -k 5 -l L2
         env:

--- a/.github/workflows/mac_arm64_run_tests.yml
+++ b/.github/workflows/mac_arm64_run_tests.yml
@@ -1,4 +1,4 @@
-name: MacOS - build package and run tests
+name: Mac ARM64 - build package and run tests
 on:
   push:
     branches:  # prevents running on tag push
@@ -11,12 +11,12 @@ jobs:
       fail-fast: false
       matrix:
         # Python 3.11 on Mac errors with "Library not loaded: '@rpath/libarmadillo.11.dylib'"
-        python-version: ["3.7", "3.8", "3.9", "3.10"]  #, "3.11"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5.6.0
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/mac_build_wheels.yml
+++ b/.github/workflows/mac_build_wheels.yml
@@ -10,25 +10,33 @@ on:
 jobs:
   build_wheels_macos:
     name: Build wheels on macos-latest
-    runs-on: macos-latest
+    runs-on: macos-13
     strategy:
       fail-fast: false
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
+      # Force compilation with LLVM's clang because Apple clang doesn't work well
       - name: Install MacOS dependencies
         run: |
-          brew install libomp armadillo
+          brew install libomp armadillo llvm
 
       # Note: CIBW only supports CPython 3.8 and newer for universal2 and arm64 wheels
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.12.0
+        uses: pypa/cibuildwheel@v2.23.3
         env:
+          MACOSX_DEPLOYMENT_TARGET: 13
           CIBW_ARCHS_MACOS: x86_64 arm64 universal2
-          CIBW_BUILD: cp*
+          CIBW_BUILD: cp310* cp311* cp312* cp313*
           CIBW_BUILD_VERBOSITY: 3
+          CC: /usr/local/opt/llvm/bin/clang
+          CXX: /usr/local/opt/llvm/bin/clang++
+          CMAKE_C_COMPILER: /usr/local/opt/llvm/bin/clang
+          CMAKE_CXX_COMPILER: /usr/local/opt/llvm/bin/clang++
+          LDFLAGS: -L/usr/local/opt/llvm/lib
+          CPPFLAGS: -I/usr/local/opt/llvm/include
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           path: ./wheelhouse/*.whl
 
@@ -36,14 +44,14 @@ jobs:
     needs: [build_wheels_macos]
     runs-on: ubuntu-latest # Can only upload from Linux containers
     steps:
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v4
         with:
           name: artifact
           path: dist
 
       - name: Upload to TestPyPI on PR update
         if: ${{ github.event_name == 'pull_request' }}
-        uses: pypa/gh-action-pypi-publish@v1.4.2
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
           password: ${{ secrets.TEST_PYPI_APIKEY }}
@@ -51,7 +59,7 @@ jobs:
 
       - name: Upload to PyPI on published release
         if: ${{ github.event_name == 'release' && github.event.action == 'published' }}
-        uses: pypa/gh-action-pypi-publish@v1.4.2
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
           password: ${{ secrets.PYPI_APIKEY }}

--- a/.github/workflows/mac_intel_cmake_build.yml
+++ b/.github/workflows/mac_intel_cmake_build.yml
@@ -1,0 +1,72 @@
+name: Mac Intel - Run CMake Build and Tests
+on:
+  push:
+    branches:  # prevents running on tag push
+      - '**'
+  pull_request:
+jobs:
+  build:
+    runs-on: macos-13
+    strategy:
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v4
+
+      # On the MacOS machine, when installing from source,
+      # we use LLVM Clang
+      - name: Install MacOS dependencies
+        run: |
+          brew install llvm libomp armadillo
+
+      - name: Install Armadillo 10.7.5+
+        run: |
+          cd ~
+          git clone https://gitlab.com/conradsnicta/armadillo-code.git
+          cd armadillo-code
+          cmake .
+          make install
+
+      - name: Install carma
+        run: |
+          cd ~
+          git clone https://github.com/RUrlus/carma.git
+          cd carma
+          mkdir build
+          cd build
+          cmake -DCARMA_INSTALL_LIB=ON ..
+          cmake --build . --config Release --target install
+          cd ~
+
+      - name: Downloading data files for tests
+        run: |
+          mkdir -p data
+          curl -XGET https://motiwari.com/banditpam_data/MNIST_1k.csv > data/MNIST_1k.csv
+
+      - name: Clone for PR
+        if: ${{ github.event_name == 'pull_request' }}
+        run: git clone -b $GITHUB_HEAD_REF https://github.com/motiwari/BanditPAM
+
+      - name: Clone for Push
+        if: ${{ github.event_name != 'pull_request' }}
+        run: git clone -b ${GITHUB_REF#refs/heads/} https://github.com/motiwari/BanditPAM
+
+      # On the MacOS machine, when installing from source,
+      # we use LLVM Clang
+      # TODO(@motiwari): Clean this environment variables up
+      - name: Verify that the C++ executable compiles and runs
+        run : |
+          echo 'export PATH="/usr/local/opt/llvm/bin:$PATH"' >> /Users/runner/.bash_profile
+          source /Users/runner/.bash_profile
+          export LDFLAGS="-L/usr/local/opt/llvm/lib, -L/usr/local/opt/llvm/lib/c++ -Wl,-rpath,/usr/local/opt/llvm/lib/c++"
+          export CPPFLAGS="-I/usr/local/opt/llvm/include"
+          export DYLD_LIBRARY_PATH=/usr/local/opt/libomp/lib:/usr/local/opt/libomp/include
+          export CC=/usr/local/opt/llvm/bin/clang
+          export CXX=/usr/local/opt/llvm/bin/clang++
+          cd BanditPAM
+          mkdir build
+          cd build
+          CC=/usr/local/opt/llvm/bin/clang CXX=/usr/local/opt/llvm/bin/clang++ cmake ..
+          make
+          src/BanditPAM -f ../data/MNIST_1k.csv -k 5 -l L2
+        env:
+          CPLUS_INCLUDE_PATH: /usr/local/include/carma:/usr/local/Cellar/libomp/15.0.2/include:/usr/local/Cellar/libomp/15.0.7/include

--- a/.github/workflows/mac_intel_run_tests.yml
+++ b/.github/workflows/mac_intel_run_tests.yml
@@ -1,4 +1,4 @@
-name: Linux - build package and run tests
+name: Mac Intel - build package and run tests
 on:
   push:
     branches:  # prevents running on tag push
@@ -6,24 +6,31 @@ on:
   pull_request:
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: macos-13
+    env:
+      CC: /usr/local/opt/llvm/bin/clang
+      CXX: /usr/local/opt/llvm/bin/clang++
+      CMAKE_C_COMPILER: /usr/local/opt/llvm/bin/clang
+      CMAKE_CXX_COMPILER: /usr/local/opt/llvm/bin/clang++
+      LDFLAGS: -L/usr/local/opt/llvm/lib
+      CPPFLAGS: -I/usr/local/opt/llvm/include
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        # Python 3.11 on Mac errors with "Library not loaded: '@rpath/libarmadillo.11.dylib'"
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
-      - uses: actions/checkout@v2
-
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5.6.0
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Install Ubuntu dependencies
+      # On the MacOS machine, when installing from source,
+      # we use LLVM Clang
+      - name: Install MacOS dependencies
         run: |
-          sudo apt update
-          sudo apt install -y build-essential checkinstall libncursesw5-dev libssl-dev libsqlite3-dev tk-dev libgdbm-dev libc6-dev libbz2-dev libffi-dev zlib1g-dev 
-          sudo apt install -y clang-format cppcheck
+          brew install llvm libomp armadillo
 
       - name: Install Python dependencies
         run: |
@@ -37,8 +44,8 @@ jobs:
           cd ~
           git clone https://gitlab.com/conradsnicta/armadillo-code.git
           cd armadillo-code
-          sudo cmake .
-          sudo make install
+          cmake .
+          make install
 
       - name: Install carma
         run: |
@@ -47,8 +54,8 @@ jobs:
           cd carma
           mkdir build
           cd build
-          sudo cmake -DCARMA_INSTALL_LIB=ON ..
-          sudo cmake --build . --config Release --target install
+          cmake -DCARMA_INSTALL_LIB=ON ..
+          cmake --build . --config Release --target install
           cd ~
 
       - name: Install BanditPAM package
@@ -56,18 +63,14 @@ jobs:
           # The flags are necessary to ignore the pyproject.toml
           # See https://github.com/pypa/pip/issues/9738
           python -m pip install --no-use-pep517 --no-build-isolation -vvv -e .
-        env:
-          # The default compiler on the Github Ubuntu runners is gcc
-          # Would need to make a respective include change for clang
-          CPLUS_INCLUDE_PATH: /usr/local/include/carma
 
       - name: Downloading data files for tests
         run: |
           mkdir -p data
+          curl -XGET https://motiwari.com/banditpam_data/MNIST_1k.csv > data/MNIST_1k.csv
           curl -XGET https://motiwari.com/banditpam_data/scRNA_1k.csv > data/scRNA_1k.csv
           curl -XGET https://motiwari.com/banditpam_data/scrna_reformat.csv.gz > data/scrna_reformat.csv.gz
           curl -XGET https://motiwari.com/banditpam_data/MNIST_100.csv > data/MNIST_100.csv
-          curl -XGET https://motiwari.com/banditpam_data/MNIST_1k.csv > data/MNIST_1k.csv
           curl -XGET https://motiwari.com/banditpam_data/MNIST_10k.tar.gz > data/MNIST_10k.tar.gz
           tar -xzvf data/MNIST_10k.tar.gz -C data
           curl -XGET https://motiwari.com/banditpam_data/MNIST_70k.tar.gz > data/MNIST_70k.tar.gz
@@ -75,25 +78,8 @@ jobs:
 
       - name: Run smaller suite of test cases
         run : |
-          pytest tests/test_smaller.py 
+          pytest tests/test_smaller.py
 
       - name: Run tests cases for initialization
         run : |
-          pytest tests/test_initialization.py 
-
-      - name: Clone for PR
-        if: ${{ github.event_name == 'pull_request' }}
-        run: git clone -b $GITHUB_HEAD_REF https://github.com/motiwari/BanditPAM
-
-      - name: Clone for Push
-        if: ${{ github.event_name != 'pull_request' }}
-        run: git clone -b ${GITHUB_REF#refs/heads/} https://github.com/motiwari/BanditPAM
-
-      - name: Verify that the C++ executable compiles and runs
-        run : |
-          cd BanditPAM
-          mkdir build
-          cd build
-          sudo cmake ..
-          sudo make
-          src/BanditPAM -f ../data/MNIST_1k.csv -k 5 -l L2
+          pytest tests/test_initialization.py

--- a/.github/workflows/run_style_checks.yml
+++ b/.github/workflows/run_style_checks.yml
@@ -10,11 +10,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5.6.0
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/run_windows_tests.yml
+++ b/.github/workflows/run_windows_tests.yml
@@ -10,11 +10,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5.6.0
         with:
           python-version: ${{ matrix.python-version }}
 


### PR DESCRIPTION
BanditPAM v5.0.0 contains several major changes:

**Organization and Functionality:**

- Updates all GHA dependencies
- Fixes all GHA on Linux and Mac, including source C++ builds, local builds, and wheel builds
- Updates supported Python versions to Python 3.10 - 3.13  
- Separates GHA by platform
- Forces LLVM's `clang` usage on Mac for compilation
- Updates `setup.py`

**Tests:**
No changes.

**Style:**
No changes.

**Documentation:**
No Changes.
