### PR TITLE
Fixing GHA again

### DIFF
--- a/.github/workflows/mac_build_wheels.yml
+++ b/.github/workflows/mac_build_wheels.yml
@@ -9,8 +9,8 @@ on:
       - published
 jobs:
   build_wheels_macos:
-    name: Build wheels on macos-13
-    runs-on: macos-13
+    name: Build wheels on macos-latest
+    runs-on: macos-latest
     strategy:
       fail-fast: false
     steps:
@@ -20,21 +20,25 @@ jobs:
       - name: Install MacOS dependencies
         run: |
           brew install libomp armadillo llvm
+          brew link llvm --force
+          brew link armadillo --force
+
 
       # Note: CIBW only supports CPython 3.8 and newer for universal2 and arm64 wheels
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.23.3
         env:
-          MACOSX_DEPLOYMENT_TARGET: 13
-          CIBW_ARCHS_MACOS: x86_64 arm64 universal2
-          CIBW_BUILD: cp310* cp311* cp312* cp313*
-          CIBW_BUILD_VERBOSITY: 3
-          CC: /usr/local/opt/llvm/bin/clang
-          CXX: /usr/local/opt/llvm/bin/clang++
-          CMAKE_C_COMPILER: /usr/local/opt/llvm/bin/clang
-          CMAKE_CXX_COMPILER: /usr/local/opt/llvm/bin/clang++
-          LDFLAGS: -L/usr/local/opt/llvm/lib
-          CPPFLAGS: -I/usr/local/opt/llvm/include
+          MACOSX_DEPLOYMENT_TARGET: "14"
+          CIBW_ARCHS_MACOS: "x86_64 arm64 universal2"
+
+          CIBW_BUILD: "cp310* cp311* cp312* cp313*"
+          CIBW_BUILD_VERBOSITY: "3"
+          CC: "/opt/homebrew/opt/llvm/bin/clang"
+          CXX: "/opt/homebrew/opt/llvm/bin/clang++"
+          CMAKE_C_COMPILER: "/opt/homebrew/opt/llvm/bin/clang"
+          CMAKE_CXX_COMPILER: "/opt/homebrew/opt/llvm/bin/clang++"
+          LDFLAGS: "-L/opt/homebrew/opt/llvm/lib -L/opt/homebrew/opt/libomp/lib"
+          CPPFLAGS: "-I/opt/homebrew/opt/llvm/include -I/opt/homebrew/opt/libomp/include"
 
       - uses: actions/upload-artifact@v4
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 license = {text = "MIT"}
-version = "6.0.0"
+version = "6.0.1"
 name = "banditpam"
 requires-python = ">= 3.10"
 authors = [
@@ -26,8 +26,6 @@ before-all = [
 
 [tool.cibuildwheel.macos]
 archs = ["x86_64", "universal2", "arm64"]
-build = ["*cp311*arm64*"]
-skip = ["*x86_64*"]
 
 # Get dependencies
 before-all = [

--- a/readme_ex1.py
+++ b/readme_ex1.py
@@ -1,0 +1,26 @@
+from banditpam import KMedoids
+import numpy as np
+import matplotlib.pyplot as plt
+
+# Generate data from a Gaussian Mixture Model with the given means:
+np.random.seed(0)
+n_per_cluster = 40
+means = np.array([[0,0], [-5,5], [5,5]])
+X = np.vstack([np.random.randn(n_per_cluster, 2) + mu for mu in means])
+
+# Fit the data with BanditPAM:
+kmed = KMedoids(n_medoids=3, algorithm="BanditPAM")
+kmed.fit(X, 'L2')
+
+print(kmed.average_loss)  # prints 1.2482391595840454
+print(kmed.labels)  # prints cluster assignments [0] * 40 + [1] * 40 + [2] * 40
+
+# Visualize the data and the medoids:
+for p_idx, point in enumerate(X):
+    if p_idx in map(int, kmed.medoids):
+        plt.scatter(X[p_idx, 0], X[p_idx, 1], color='red', s = 40)
+    else:
+        plt.scatter(X[p_idx, 0], X[p_idx, 1], color='blue', s = 10)
+
+plt.show()
+

--- a/scripts/docker/cibw_before_all_macos.sh
+++ b/scripts/docker/cibw_before_all_macos.sh
@@ -2,10 +2,10 @@ cd ~
 git clone https://gitlab.com/conradsnicta/armadillo-code.git
 git clone https://github.com/RUrlus/carma.git --recursive # Do we need this?
 cd ~/armadillo-code
-cmake .
-make install
+sudo cmake .
+sudo make install
 cd ~/carma
 mkdir -p build
 cd build
-cmake -DCARMA_INSTALL_LIB=ON ..
+sudo cmake -DCARMA_INSTALL_LIB=ON ..
 sudo cmake --build . --config Release --target install


### PR DESCRIPTION
BanditPAM `v.6.0.1` fixes the previously broken BanditPAM `v.5.0.0` by:

- Updating the Mac wheels to be built on an m1 `macos-latest` instead of an intel `macos-13`
- Statically linking OpenMP