### PR TITLE
BanditPAM `v6.0.2`

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -2,7 +2,8 @@
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
-    branches: [main, master]
+    branches:  # prevents running on tag push
+      - '**'
   pull_request:
 
 name: R-CMD-check.yaml

--- a/.github/workflows/linux_build_wheels.yml
+++ b/.github/workflows/linux_build_wheels.yml
@@ -78,7 +78,7 @@ jobs:
         with:
           user: __token__
           password: ${{ secrets.TEST_PYPI_APIKEY }}
-          repository_url: https://test.pypi.org/legacy/
+          repository-url: https://test.pypi.org/legacy/
 
       - name: Upload to PyPI on published release
         if: ${{ github.event_name == 'release' && github.event.action == 'published' }}

--- a/.github/workflows/linux_run_tests.yml
+++ b/.github/workflows/linux_run_tests.yml
@@ -55,7 +55,7 @@ jobs:
         run: |
           # The flags are necessary to ignore the pyproject.toml
           # See https://github.com/pypa/pip/issues/9738
-          python -m pip install --no-use-pep517 --no-build-isolation -vvv -e .
+          python -m pip install --no-use-pep517 --no-build-isolation -v -e .
         env:
           # The default compiler on the Github Ubuntu runners is gcc
           # Would need to make a respective include change for clang

--- a/.github/workflows/mac_arm64_run_tests.yml
+++ b/.github/workflows/mac_arm64_run_tests.yml
@@ -45,6 +45,7 @@ jobs:
           cd ~
           git clone https://gitlab.com/conradsnicta/armadillo-code.git
           cd armadillo-code
+          git checkout tags/14.6.3
           sudo cmake .
           sudo make install
 

--- a/.github/workflows/mac_arm64_run_tests.yml
+++ b/.github/workflows/mac_arm64_run_tests.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         # Python 3.11 on Mac errors with "Library not loaded: '@rpath/libarmadillo.11.dylib'"
-        python-version: ["3.10"] #, "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
 
@@ -66,7 +66,7 @@ jobs:
         run: |
           # The flags are necessary to ignore the pyproject.toml
           # See https://github.com/pypa/pip/issues/9738
-          python -m pip install --no-use-pep517 --no-build-isolation -vvv -e .
+          python -m pip install --no-use-pep517 --no-build-isolation -v -e .
         env:
           # The default compiler on the Github Ubuntu runners is gcc
           # Would need to make a respective include change for clang

--- a/.github/workflows/mac_arm64_run_tests.yml
+++ b/.github/workflows/mac_arm64_run_tests.yml
@@ -29,9 +29,11 @@ jobs:
 
       # On the MacOS machine, when installing from source,
       # we use LLVM Clang
+      # Note: we need to include armadillo here even though we install armadillo from source
+      #  to create the correct folders
       - name: Install MacOS dependencies
         run: |
-          brew install llvm libomp
+          brew install llvm libomp armadillo
 
       - name: Install Python dependencies
         run: |

--- a/.github/workflows/mac_arm64_run_tests.yml
+++ b/.github/workflows/mac_arm64_run_tests.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         # Python 3.11 on Mac errors with "Library not loaded: '@rpath/libarmadillo.11.dylib'"
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10"] #, "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
 
@@ -31,7 +31,7 @@ jobs:
       # we use LLVM Clang
       - name: Install MacOS dependencies
         run: |
-          brew install llvm libomp armadillo
+          brew install llvm libomp
 
       - name: Install Python dependencies
         run: |

--- a/.github/workflows/mac_build_wheels.yml
+++ b/.github/workflows/mac_build_wheels.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.23.3
         env:
-          MACOSX_DEPLOYMENT_TARGET: "14"
+          MACOSX_DEPLOYMENT_TARGET: "15"
           CIBW_ARCHS_MACOS: "x86_64 arm64 universal2"
 
           CIBW_BUILD: "cp310* cp311* cp312* cp313*"

--- a/.github/workflows/mac_build_wheels.yml
+++ b/.github/workflows/mac_build_wheels.yml
@@ -59,7 +59,7 @@ jobs:
         with:
           user: __token__
           password: ${{ secrets.TEST_PYPI_APIKEY }}
-          repository_url: https://test.pypi.org/legacy/
+          repository-url: https://test.pypi.org/legacy/
 
       - name: Upload to PyPI on published release
         if: ${{ github.event_name == 'release' && github.event.action == 'published' }}

--- a/.github/workflows/mac_intel_run_tests.yml
+++ b/.github/workflows/mac_intel_run_tests.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         # Python 3.11 on Mac errors with "Library not loaded: '@rpath/libarmadillo.11.dylib'"
-        python-version: ["3.10"] #, "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
@@ -65,7 +65,7 @@ jobs:
         run: |
           # The flags are necessary to ignore the pyproject.toml
           # See https://github.com/pypa/pip/issues/9738
-          python -m pip install --no-use-pep517 --no-build-isolation -vvv -e .
+          python -m pip install --no-use-pep517 --no-build-isolation -v -e .
 
       - name: Downloading data files for tests
         run: |

--- a/.github/workflows/mac_intel_run_tests.yml
+++ b/.github/workflows/mac_intel_run_tests.yml
@@ -44,6 +44,7 @@ jobs:
           cd ~
           git clone https://gitlab.com/conradsnicta/armadillo-code.git
           cd armadillo-code
+          git checkout tags/14.6.3
           cmake .
           make install
 

--- a/.github/workflows/mac_intel_run_tests.yml
+++ b/.github/workflows/mac_intel_run_tests.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         # Python 3.11 on Mac errors with "Library not loaded: '@rpath/libarmadillo.11.dylib'"
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10"] #, "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
@@ -30,7 +30,7 @@ jobs:
       # we use LLVM Clang
       - name: Install MacOS dependencies
         run: |
-          brew install llvm libomp armadillo
+          brew install llvm libomp
 
       - name: Install Python dependencies
         run: |

--- a/.github/workflows/mac_intel_run_tests.yml
+++ b/.github/workflows/mac_intel_run_tests.yml
@@ -28,9 +28,11 @@ jobs:
 
       # On the MacOS machine, when installing from source,
       # we use LLVM Clang
+      # Note: we need to include armadillo here even though we install armadillo from source
+      #  to create the correct folders
       - name: Install MacOS dependencies
         run: |
-          brew install llvm libomp
+          brew install llvm libomp armadillo
 
       - name: Install Python dependencies
         run: |

--- a/.github/workflows/run_windows_tests.yml
+++ b/.github/workflows/run_windows_tests.yml
@@ -86,11 +86,11 @@ jobs:
           cd BanditPAM
           # The flags are necessary to ignore the pyproject.toml
           # See https://github.com/pypa/pip/issues/9738
-          python -m pip install -vvvv --no-use-pep517 .
+          python -m pip install -v --no-use-pep517 .
           cd scripts
           sh retrieve_windows_python_files.sh
           cd ..
-          python -m pip install -vvvv --no-use-pep517 .
+          python -m pip install -v --no-use-pep517 .
 
       - name: Run smaller suite of test cases
         run: |

--- a/README.md
+++ b/README.md
@@ -12,19 +12,30 @@
 [![Run style checks](https://github.com/motiwari/BanditPAM/actions/workflows/run_style_checks.yml/badge.svg)](https://github.com/motiwari/BanditPAM/actions/workflows/run_style_checks.yml)
 
 
-This repo contains a high-performance implementation of BanditPAM from [BanditPAM: Almost Linear-Time k-Medoids Clustering](https://proceedings.neurips.cc/paper/2020/file/73b817090081cef1bca77232f4532c5d-Paper.pdf). The code can be called directly from Python, R, or C++.
+This repo contains a high-performance implementation of BanditPAM from [BanditPAM: Almost Linear-Time k-Medoids Clustering](https://proceedings.neurips.cc/paper/2020/file/73b817090081cef1bca77232f4532c5d-Paper.pdf) and [BanditPAM++: Faster k-medoids Clustering](https://proceedings.neurips.cc/paper_files/paper/2023/file/e885e5bc6e13b9dd8f80bc5482b1fa2f-Paper-Conference.pdf). The code can be called directly from Python, R, or C++.
 
 If you use this software, please cite:
 
 Mo Tiwari, Martin Jinye Zhang, James Mayclin, Sebastian Thrun, Chris Piech, Ilan Shomorony. "BanditPAM: Almost Linear Time *k*-medoids Clustering via Multi-Armed Bandits" Advances in Neural Information Processing Systems (NeurIPS) 2020.
 
+Mo Tiwari, Ryan Kang*, Donghyun Lee*, Sebastian Thrun, Chris Piech, Ilan Shomorony, Martin Jinye Zhang. "BanditPAM++: Faster k-medoids Clustering" Advances in Neural Information Processing Systems (NeurIPS) 2023.
+
 ```python
-@inproceedings{BanditPAM,
-  title={BanditPAM: Almost Linear Time k-medoids Clustering via Multi-Armed Bandits},
+@inproceedings{tiwari2020banditpam,
+  title={BanditPAM: Almost Linear Time $k$-medoids Clustering via Multi-Armed Bandits},
   author={Tiwari, Mo and Zhang, Martin J and Mayclin, James and Thrun, Sebastian and Piech, Chris and Shomorony, Ilan},
   booktitle={Advances in Neural Information Processing Systems},
   pages={368--374},
   year={2020}
+}
+
+@inproceedings{tiwari2023banditpam++,
+  title={BanditPAM++: Faster $k$-medoids Clustering},
+  author={Tiwari, Mo and Kang, Ryan and Lee, Donghyun and Thrun, Sebastian and Shomorony, Ilan and Zhang, Martin J},
+  journal={Advances in Neural Information Processing Systems},
+  volume={36},
+  pages={73371--73382},
+  year={2023}
 }
 ```
 
@@ -34,7 +45,8 @@ Mo Tiwari, Martin Jinye Zhang, James Mayclin, Sebastian Thrun, Chris Piech, Ilan
 If you have any difficulties, please see the [platform-specific guides](https://github.com/motiwari/BanditPAM#platform-specific-installation-guides) and file a Github issue if you have additional trouble.
 
 ## Further Reading
-* [Full paper](https://proceedings.neurips.cc/paper/2020/file/73b817090081cef1bca77232f4532c5d-Paper.pdf)
+* [NeurIPS 2020 Paper](https://proceedings.neurips.cc/paper/2020/file/73b817090081cef1bca77232f4532c5d-Paper.pdf)
+* [NeurIPS 2023 Paper](https://proceedings.neurips.cc/paper_files/paper/2023/file/e885e5bc6e13b9dd8f80bc5482b1fa2f-Paper-Conference.pdf)
 * [3-minute summary video](https://slideslive.com/38936275/banditpam-almost-linear-time-kmedoids-clustering-via-multiarmed-bandits)
 * [Blog post](https://ai.stanford.edu/blog/banditpam/)
 * [Code](https://github.com/motiwari/BanditPAM)

--- a/R_package/banditpam/README.md
+++ b/R_package/banditpam/README.md
@@ -5,21 +5,32 @@
 <!-- badges: end -->
 
 We provide an R interface to the high-performance implementation of
-[banditpam](https://proceedings.neurips.cc/paper/2020/file/73b817090081cef1bca77232f4532c5d-Paper.pdf),
+[BanditPAM](https://proceedings.neurips.cc/paper/2020/file/73b817090081cef1bca77232f4532c5d-Paper.pdf) and [BanditPAM++](https://proceedings.neurips.cc/paper_files/paper/2023/file/e885e5bc6e13b9dd8f80bc5482b1fa2f-Paper-Conference.pdf),
 a $k$-medoids clustering algorithm.
 
 If you use this software, please cite:
 
->>Mo Tiwari, Martin Jinye Zhang, James Mayclin, Sebastian Thrun, Chris Piech, Ilan Shomorony. "banditpam: Almost Linear Time *k*-medoids Clustering via Multi-Armed Bandits" Advances in Neural Information Processing Systems (NeurIPS) 2020.
+>>Mo Tiwari, Martin Jinye Zhang, James Mayclin, Sebastian Thrun, Chris Piech, Ilan Shomorony. "BanditPAM: Almost Linear Time *k*-medoids Clustering via Multi-Armed Bandits" Advances in Neural Information Processing Systems (NeurIPS) 2020.
 
-Here's a BibTeX entry:
+>>Mo Tiwari, Ryan Kang*, Donghyun Lee*, Sebastian Thrun, Chris Piech, Ilan Shomorony, Martin Jinye Zhang. "BanditPAM++: Faster k-medoids Clustering" Advances in Neural Information Processing Systems (NeurIPS) 2023.
+
+Here's the BibTeX:
 ```
-@inproceedings{banditpam,
-  title={banditpam: Almost Linear Time k-medoids Clustering via Multi-Armed Bandits},
+@inproceedings{tiwari2020banditpam,
+  title={BanditPAM: Almost Linear Time %k%-medoids Clustering via Multi-Armed Bandits},
   author={Tiwari, Mo and Zhang, Martin J and Mayclin, James and Thrun, Sebastian and Piech, Chris and Shomorony, Ilan},
   booktitle={Advances in Neural Information Processing Systems},
   pages={368--374},
   year={2020}
+}
+
+@inproceedings{tiwari2023banditpam++,
+  title={BanditPAM++: Faster $k$-medoids Clustering},
+  author={Tiwari, Mo and Kang, Ryan and Lee, Donghyun and Thrun, Sebastian and Shomorony, Ilan and Zhang, Martin J},
+  journal={Advances in Neural Information Processing Systems},
+  volume={36},
+  pages={73371--73382},
+  year={2023}
 }
 ```
 

--- a/R_package/banditpam/src/kmedoids.cpp
+++ b/R_package/banditpam/src/kmedoids.cpp
@@ -150,7 +150,7 @@ SEXP KMedoids__get_build_conf(SEXP xp) {
 //// Set the build_conf property
 ////
 //// @param xp the km::KMedoids Object XPtr
-// [[Rcpp::export(.KMedoids__set_iter)]]
+// [[Rcpp::export(.KMedoids__set_build_conf)]]
 void KMedoids__set_build_conf(SEXP xp, IntegerVector bc) {
   // grab the object as a XPtr (smart pointer)
   XPtr<km::KMedoids> ptr(xp);
@@ -170,11 +170,24 @@ SEXP KMedoids__get_swap_conf(SEXP xp) {
 //// Set the swap_conf property
 ////
 //// @param xp the km::KMedoids Object XPtr
-// [[Rcpp::export(.KMedoids__set_iter)]]
+// [[Rcpp::export(.KMedoids__set_swap_conf)]]
 void KMedoids__set_swap_conf(SEXP xp, IntegerVector bc) {
   // grab the object as a XPtr (smart pointer)
   XPtr<km::KMedoids> ptr(xp);
   ptr->setSwapConfidence(bc[0]);
+}
+
+//// Convenience function to convert LossType to string
+////
+//// @param lt the km::KMedoids LossType
+// [[Rcpp::export(.loss_to_string)]]
+static inline std::string loss_to_string(km::LossType lt) {
+    switch (lt) {
+        case km::LossType::L2: return "L2";
+        case km::LossType::L1: return "L1";
+        // add others...
+        default: return "unknown";
+    }
 }
 
 //// Return the loss_fn property
@@ -184,7 +197,7 @@ void KMedoids__set_swap_conf(SEXP xp, IntegerVector bc) {
 SEXP KMedoids__get_loss_fn(SEXP xp) {
   // grab the object as a XPtr (smart pointer)
   XPtr<km::KMedoids> ptr(xp);
-  return wrap(ptr->getLossFn());
+  return wrap(loss_to_string(ptr->getLossFn()));
 }
 
 //// Set the loss_fn property

--- a/R_package/banditpam/src/kmedoids.cpp
+++ b/R_package/banditpam/src/kmedoids.cpp
@@ -183,9 +183,13 @@ void KMedoids__set_swap_conf(SEXP xp, IntegerVector bc) {
 // [[Rcpp::export(.loss_to_string)]]
 static inline std::string loss_to_string(km::LossType lt) {
     switch (lt) {
-        case km::LossType::L2: return "L2";
-        case km::LossType::L1: return "L1";
-        // add others...
+        case km::LossType::MANHATTAN: return "manhattan";
+        case km::LossType::COS: return "cos";
+        case km::LossType::COSINE: return "cos";
+        case km::LossType::INF: return "inf";
+        case km::LossType::EUCLIDEAN: return "euclidean";
+        case km::LossType::LP_NORM: return "lp";
+        case km::LossType::UNKNOWN: return "unknown";
         default: return "unknown";
     }
 }

--- a/R_package/banditpam/src/kmedoids_algorithm.cpp
+++ b/R_package/banditpam/src/kmedoids_algorithm.cpp
@@ -267,7 +267,7 @@ void KMedoids::setLossFn(std::string loss) {
     c = ::tolower(c);  // TODO(@motiwari): Put something before ::
   });
   
-  switch (getLossType(loss)) {
+  switch (KMedoids::getLossType(loss)) {
     case LossType::MANHATTAN:
       lossFn = &KMedoids::manhattan;
       break;

--- a/R_package/banditpam/src/kmedoids_algorithm.hpp
+++ b/R_package/banditpam/src/kmedoids_algorithm.hpp
@@ -12,6 +12,25 @@
 #include <string>
 
 namespace km {
+
+/**
+ * @brief Enum for different loss function types
+ */
+enum class LossType {
+  MANHATTAN,
+  COS,
+  COSINE,
+  INF,
+  EUCLIDEAN,
+  LP_NORM,
+  UNKNOWN
+};
+
+/**
+ * @brief Enum for different distance categories
+ */
+enum class AlgorithmStep { MISC, BUILD, SWAP };
+
 /**
  * @brief KMedoids class. Creates a KMedoids object that can be used to find the medoids
  * for a particular set of input data.

--- a/R_package/banditpam/src/kmedoids_algorithm.hpp
+++ b/R_package/banditpam/src/kmedoids_algorithm.hpp
@@ -209,7 +209,7 @@ class KMedoids {
    *
    * @returns Loss function currently being recognized
    */
-  std::string getLossFn() const;
+  LossType getLossFn() const;
 
   /**
    * @brief Get the average loss from the prior clustering

--- a/R_package/banditpam/src/kmedoids_algorithm.hpp
+++ b/R_package/banditpam/src/kmedoids_algorithm.hpp
@@ -10,6 +10,7 @@
 #include <functional>
 #include <unordered_map>
 #include <string>
+#include <regex>
 
 namespace km {
 

--- a/R_package/banditpam/src/kmedoids_algorithm.hpp
+++ b/R_package/banditpam/src/kmedoids_algorithm.hpp
@@ -481,6 +481,30 @@ class KMedoids {
    */
   void checkAlgorithm(const std::string& algorithm) const;
 
+    /**
+   * @brief Converts a string loss function name to LossType enum
+   *
+   * @param loss The loss function string
+   * @returns The corresponding LossType enum value
+   */
+  LossType getLossType(const std::string &loss) const {
+    if (loss == "manhattan") {
+      return LossType::MANHATTAN;
+    } else if (loss == "cos") {
+      return LossType::COS;
+    } else if (loss == "cosine") {
+      return LossType::COSINE;
+    } else if (loss == "inf") {
+      return LossType::INF;
+    } else if (loss == "euclidean") {
+      return LossType::EUCLIDEAN;
+    } else if (std::regex_match(loss, std::regex("l\\d*"))) {
+      return LossType::LP_NORM;
+    } else {
+      return LossType::UNKNOWN;
+    }
+  }
+
   /// Number of medoids to use -- the "k" in k-medoids
   size_t nMedoids;
 

--- a/docs/install_mac.md
+++ b/docs/install_mac.md
@@ -1,6 +1,6 @@
 # Installation Tutorial for MacOS
 
-The following is a more detailed description of the installation process of BanditPAM for MacOS.
+The following is a more detailed description of the installation process of BanditPAM for MacOS 15.0+.
 
 ## Prerequisites
 Please ensure the following dependencies are installed:

--- a/headers/algorithms/kmedoids_algorithm.hpp
+++ b/headers/algorithms/kmedoids_algorithm.hpp
@@ -31,11 +31,7 @@ enum class LossType {
 /**
  * @brief Enum for different distance categories
  */
-enum class AlgorithmStep {
-  MISC,
-  BUILD,
-  SWAP
-};
+enum class AlgorithmStep { MISC, BUILD, SWAP };
 
 /**
  * @brief KMedoids class. Creates a KMedoids object that can be used to find the
@@ -468,7 +464,7 @@ class KMedoids {
    * @returns The Manhattan distance between points i and j
    */
   float manhattan(const arma::fmat &data, const size_t i, const size_t j) const;
-    
+
   /**
    * @brief Assigns ranks to each element in the input vector.
    * Smallest element receives rank 1, the next 2, and so on.
@@ -476,9 +472,10 @@ class KMedoids {
    *
    * @param vec A vector containing the elements to be ranked.
    *
-   * @returns A vector of the same size as `vec`, with each element replaced by its rank.
+   * @returns A vector of the same size as `vec`, with each element replaced by
+   * its rank.
    */
-  arma::fvec rank(const arma::fvec& vec) const;
+  arma::fvec rank(const arma::fvec &vec) const;
 
   /**
    * @brief Computes the Pearson correlation between the
@@ -491,7 +488,8 @@ class KMedoids {
    * @returns The Pearson correlation between points i and j
    */
   float pearson(const arma::fmat &data, const size_t i, const size_t j) const;
-  float clippedCos(const arma::fmat &data, const size_t i, const size_t j) const;
+  float clippedCos(const arma::fmat &data, const size_t i,
+                   const size_t j) const;
 
   /**
    * @brief Computes the Spearman correlation between the
@@ -517,7 +515,7 @@ class KMedoids {
 
   /**
    * @brief Converts a string loss function name to LossType enum
-   * 
+   *
    * @param loss The loss function string
    * @returns The corresponding LossType enum value
    */

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-license = {text = "MIT"}
+license = "MIT"
 version = "6.0.2"
 name = "banditpam"
 requires-python = ">= 3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-license = "MIT"
+license = {text = "MIT"}
 version = "6.0.2"
 name = "banditpam"
 requires-python = ">= 3.10"

--- a/readme_ex1.py
+++ b/readme_ex1.py
@@ -5,7 +5,7 @@ import matplotlib.pyplot as plt
 # Generate data from a Gaussian Mixture Model with the given means:
 np.random.seed(0)
 n_per_cluster = 40
-means = np.array([[0,0], [-5,5], [5,5]])
+means = np.array([[0, 0], [-5, 5], [5, 5]])
 X = np.vstack([np.random.randn(n_per_cluster, 2) + mu for mu in means])
 
 # Fit the data with BanditPAM:

--- a/readme_ex1.py
+++ b/readme_ex1.py
@@ -18,9 +18,8 @@ print(kmed.labels)  # prints cluster assignments [0] * 40 + [1] * 40 + [2] * 40
 # Visualize the data and the medoids:
 for p_idx, point in enumerate(X):
     if p_idx in map(int, kmed.medoids):
-        plt.scatter(X[p_idx, 0], X[p_idx, 1], color='red', s = 40)
+        plt.scatter(X[p_idx, 0], X[p_idx, 1], color='red', s=40)
     else:
-        plt.scatter(X[p_idx, 0], X[p_idx, 1], color='blue', s = 10)
+        plt.scatter(X[p_idx, 0], X[p_idx, 1], color='blue', s=10)
 
 plt.show()
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pandas>=0.24.1
-pybind11>=2.5.0
+pybind11>=3.0.0
 numpy>=1.16.2
 matplotlib>=3.2.1
 myst-parser>=0.16.0

--- a/scripts/docker/cibw_before_all_macos.sh
+++ b/scripts/docker/cibw_before_all_macos.sh
@@ -2,6 +2,7 @@ cd ~
 git clone https://gitlab.com/conradsnicta/armadillo-code.git
 git clone https://github.com/RUrlus/carma.git --recursive # Do we need this?
 cd ~/armadillo-code
+git checkout tags/14.6.3  # Pin armadillo
 sudo cmake .
 sudo make install
 cd ~/carma

--- a/setup.py
+++ b/setup.py
@@ -502,9 +502,8 @@ def main():
             "headers",
             os.path.join("headers", "algorithms"),
             os.path.join("headers", "python_bindings"),
-            os.path.join("../", "carma", "include"),
-            # os.path.join("headers", "carma", "include"),
-            # os.path.join("headers", "carma", "include", "carma_bits"),
+            os.path.join("headers", "carma", "include"),
+            os.path.join("headers", "carma", "include", "carma_bits"),
             os.path.join("/", "usr", "local", "include"),
         
         ]

--- a/setup.py
+++ b/setup.py
@@ -447,7 +447,8 @@ class BuildExt(build_ext):
                 for package in ["libomp"]:
                     package_prefix = get_package_prefix(package)
                     comp_opts.append("-I{}/include".format(package_prefix))
-                    comp_opts.append("-L{}/lib".format(package_prefix))  # Remove?
+                    # Remove addition to comp_opts?
+                    comp_opts.append("-L{}/lib".format(package_prefix))
                     link_opts.append("-L{}/lib".format(package_prefix))
         elif sys.platform == "linux":
             link_opts += ["-lm", "-lpthread"]
@@ -456,10 +457,10 @@ class BuildExt(build_ext):
 
         compiler_name = compiler_check()
         # if sys.platform == "darwin":
-            # if compiler_name == "gcc":
-            #      link_opts.append("-lomp")
-            # else:
-            #     link_opts.append("-lomp")
+        #     if compiler_name == "gcc":
+        #         link_opts.append("-lomp")
+        #     else:
+        #         link_opts.append("-lomp")
         if sys.platform == "linux" or sys.platform == "linux2":
             if compiler_name == "gcc":
                 link_opts += ["-lgomp", "-lm", "-lpthread"]
@@ -488,8 +489,8 @@ class BuildExt(build_ext):
             ext.extra_link_args = link_opts
             ext.extra_link_args += [
                 "-v",
-            ] # "-arch", "x86_64"]
-            ext.extra_link_args =  link_opts
+            ]  # "-arch", "x86_64"]
+            ext.extra_link_args = link_opts
 
         build_ext.build_extensions(self)
 
@@ -505,7 +506,6 @@ def main():
             os.path.join("headers", "carma", "include"),
             os.path.join("headers", "carma", "include", "carma_bits"),
             os.path.join("/", "usr", "local", "include"),
-        
         ]
     elif sys.platform == "darwin":  # OSX
         include_dirs = [
@@ -561,8 +561,8 @@ def main():
 
     compiler_name = compiler_check()
     if sys.platform == "darwin" and os.environ.get(GHA, False):
-        # Do NOT link omp here because it'll add an -lomp flag to dynamically link it
-        #  (and we want to statically link it)
+        # Do NOT link omp here because it'll add an -lomp flag to
+        #  dynamically link it (and we want to statically link it)
         libraries = ["armadillo"]
     elif sys.platform == "win32":
         libraries = ["libopenblas"]
@@ -611,7 +611,6 @@ def main():
                 os.path.join(
                     "src", "python_bindings", "swap_times_python.cpp"
                 ),
-                
             ],
             include_dirs=include_dirs,
             library_dirs=library_dirs,

--- a/setup.py
+++ b/setup.py
@@ -394,7 +394,7 @@ class BuildExt(build_ext):
         ), "Need to install LLVM clang!"
         darwin_opts = [
             "-stdlib=libc++",
-            "-mmacosx-version-min=10.14",
+            "-mmacosx-version-min=15.0",
             "-O3",
         ]
         c_opts["unix"] += darwin_opts

--- a/setup.py
+++ b/setup.py
@@ -617,8 +617,7 @@ def main():
             libraries=libraries,
             language="c++1z",  # TODO: modify this based on cpp_flag(compiler)
             extra_compile_args=cpp_args,
-            # Not passed? (BuildExt sets extra_link_args)
-            extra_link_args=["-vvvv"],
+            extra_link_args=["-v"],
         )
     ]
 

--- a/setup.py
+++ b/setup.py
@@ -649,7 +649,7 @@ def main():
         url="https://github.com/motiwari/BanditPAM",
         long_description=long_description,
         ext_modules=ext_modules,
-        setup_requires=["pybind11>=2.5.0", "numpy>=1.18"],
+        setup_requires=["pybind11>=3.0.0", "numpy>=1.18"],
         data_files=my_data_files,
         include_package_data=True,
         cmdclass={"build_ext": BuildExt},

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,60 +1,57 @@
-include_directories(${PROJECT_SOURCE_DIR} / headers) include_directories(
-  ${PROJECT_SOURCE_DIR} / headers /
-  algorithms) include_directories(${PROJECT_SOURCE_DIR} / headers /
-                                  python_bindings)
-  include_directories(${PROJECT_SOURCE_DIR} / headers / carma /
-                      include) include_directories(${PROJECT_SOURCE_DIR} /
-                                                   headers / carma / include /
-                                                   carma_bits)
-#As per README instructions, \
-  we expected the user to have cloned armadillo locally
-    if (WIN32) include_directories(
-      ${PROJECT_SOURCE_DIR} / headers / armadillo /
-      include) include_directories(${PROJECT_SOURCE_DIR} / headers / armadillo /
-                                   include / armadillo_bits)
-      set(OPENBLAS_dir ${PROJECT_SOURCE_DIR} / headers / armadillo / examples /
-          lib_win64) endif()
+include_directories(${PROJECT_SOURCE_DIR}/headers)
+include_directories(${PROJECT_SOURCE_DIR}/headers/algorithms)
+include_directories(${PROJECT_SOURCE_DIR}/headers/python_bindings)
+include_directories(${PROJECT_SOURCE_DIR}/headers/carma/include)
+include_directories(${PROJECT_SOURCE_DIR}/headers/carma/include/carma_bits)
+# As per README instructions, we expected the user to have cloned armadillo locally
+if(WIN32)
+    include_directories(${PROJECT_SOURCE_DIR}/headers/armadillo/include)
+    include_directories(
+            ${PROJECT_SOURCE_DIR}/headers/armadillo/include/armadillo_bits)
+    set(OPENBLAS_dir ${PROJECT_SOURCE_DIR}/headers/armadillo/examples/lib_win64)
+endif()
 
-#For Mac Github Runner to find OpenMP-- potentially unnecessary after fixing
-#- Xpreprocessor - fopenmp issue
-        if (APPLE OR UNIX) include_directories(/ usr / local / Cellar / libomp /
-                                               15.0.2 / include)
-          include_directories(/ usr / local / Cellar / libomp / 15.0.7 /
-                              include) include_directories(/ usr / local /
-                                                           Cellar / libomp)
-            include_directories(/ usr / local / opt / libomp /
-                                include) include_directories(/ usr / local /
-                                                             opt / libomp / lib)
-              include_directories(/ usr / local / opt /
-                                  libomp) include_directories(/ usr / local /
-                                                              opt) endif()
+# For Mac Github Runner to find OpenMP -- potentially unnecessary after fixing
+# -Xpreprocessor -fopenmp issue
+if(APPLE OR UNIX)
+    include_directories(/usr/local/Cellar/libomp/15.0.2/include)
+    include_directories(/usr/local/Cellar/libomp/15.0.7/include)
+    include_directories(/usr/local/Cellar/libomp)
+    include_directories(/usr/local/opt/libomp/include)
+    include_directories(/usr/local/opt/libomp/lib)
+    include_directories(/usr/local/opt/libomp)
+    include_directories(/usr/local/opt)
+endif()
 
-                if (WIN32) add_executable(BanditPAM getopt.cpp main.cpp) elseif(
-                  APPLE OR UNIX) add_executable(BanditPAM main.cpp) endif()
-                  add_library(BanditPAM_LIB algorithms /
-                              kmedoids_algorithm.cpp algorithms /
-                              pam.cpp algorithms / banditpam.cpp algorithms /
-                              banditpam_orig.cpp algorithms / fastpam1.cpp)
+if(WIN32)
+    add_executable(BanditPAM getopt.cpp main.cpp )
+elseif(APPLE OR UNIX)
+    add_executable(BanditPAM main.cpp )
+endif()
+add_library(
+        BanditPAM_LIB algorithms/kmedoids_algorithm.cpp
+        algorithms/pam.cpp
+        algorithms/banditpam.cpp
+        algorithms/banditpam_orig.cpp
+        algorithms/fastpam1.cpp)
 
-                    target_link_libraries(BanditPAM PUBLIC BanditPAM_LIB)
+target_link_libraries(BanditPAM PUBLIC BanditPAM_LIB)
 
-                      if (WIN32) target_link_directories(BanditPAM PUBLIC ${
-                        OPENBLAS_dir})
-                        target_link_libraries(BanditPAM_LIB libopenblas) endif()
+if(WIN32)
+    target_link_directories(BanditPAM PUBLIC ${OPENBLAS_dir})
+    target_link_libraries(BanditPAM_LIB libopenblas)
+endif()
 
-                          if (APPLE OR UNIX) find_package(Armadillo REQUIRED)
-                            include_directories(${ARMADILLO_INCLUDE_DIRS})
-                              target_link_libraries(BanditPAM PUBLIC ${
-                                ARMADILLO_LIBRARIES}) endif()
+if(APPLE OR UNIX)
+    find_package(Armadillo REQUIRED)
+    include_directories(${ARMADILLO_INCLUDE_DIRS})
+    target_link_libraries(BanditPAM PUBLIC ${ARMADILLO_LIBRARIES})
+endif()
 
-                                if (WIN32)
-#Windows uses backslashes for paths while Unix systems use forward slashes
-                                  string(REPLACE
-                                         "/"
-                                         "\\" OPENBLAS_dir_win ${OPENBLAS_dir})
-#Copy all DLLs from OPENBLAS_dir_win to the output directory
-                                    add_custom_command(
-                                      TARGET BanditPAM_LIB POST_BUILD COMMAND
-                                        copy $ {
-                                          OPENBLAS_dir_win
-                                        }\\*.dll $(OutDir)) endif()
+if(WIN32)
+    # Windows uses backslashes for paths while Unix systems use forward slashes
+    string(REPLACE "/" "\\"  OPENBLAS_dir_win ${OPENBLAS_dir})
+    # Copy all DLLs from OPENBLAS_dir_win to the output directory
+    add_custom_command(TARGET BanditPAM_LIB POST_BUILD
+                COMMAND copy ${OPENBLAS_dir_win}\\*.dll $(OutDir))
+endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,57 +1,60 @@
-include_directories(${PROJECT_SOURCE_DIR}/headers)
-include_directories(${PROJECT_SOURCE_DIR}/headers/algorithms)
-include_directories(${PROJECT_SOURCE_DIR}/headers/python_bindings)
-include_directories(${PROJECT_SOURCE_DIR}/headers/carma/include)
-include_directories(${PROJECT_SOURCE_DIR}/headers/carma/include/carma_bits)
-# As per README instructions, we expected the user to have cloned armadillo locally
-if(WIN32)
-    include_directories(${PROJECT_SOURCE_DIR}/headers/armadillo/include)
-    include_directories(
-            ${PROJECT_SOURCE_DIR}/headers/armadillo/include/armadillo_bits)
-    set(OPENBLAS_dir ${PROJECT_SOURCE_DIR}/headers/armadillo/examples/lib_win64)
-endif()
+include_directories(${PROJECT_SOURCE_DIR} / headers) include_directories(
+  ${PROJECT_SOURCE_DIR} / headers /
+  algorithms) include_directories(${PROJECT_SOURCE_DIR} / headers /
+                                  python_bindings)
+  include_directories(${PROJECT_SOURCE_DIR} / headers / carma /
+                      include) include_directories(${PROJECT_SOURCE_DIR} /
+                                                   headers / carma / include /
+                                                   carma_bits)
+#As per README instructions, \
+  we expected the user to have cloned armadillo locally
+    if (WIN32) include_directories(
+      ${PROJECT_SOURCE_DIR} / headers / armadillo /
+      include) include_directories(${PROJECT_SOURCE_DIR} / headers / armadillo /
+                                   include / armadillo_bits)
+      set(OPENBLAS_dir ${PROJECT_SOURCE_DIR} / headers / armadillo / examples /
+          lib_win64) endif()
 
-# For Mac Github Runner to find OpenMP -- potentially unnecessary after fixing
-# -Xpreprocessor -fopenmp issue
-if(APPLE OR UNIX)
-    include_directories(/usr/local/Cellar/libomp/15.0.2/include)
-    include_directories(/usr/local/Cellar/libomp/15.0.7/include)
-    include_directories(/usr/local/Cellar/libomp)
-    include_directories(/usr/local/opt/libomp/include)
-    include_directories(/usr/local/opt/libomp/lib)
-    include_directories(/usr/local/opt/libomp)
-    include_directories(/usr/local/opt)
-endif()
+#For Mac Github Runner to find OpenMP-- potentially unnecessary after fixing
+#- Xpreprocessor - fopenmp issue
+        if (APPLE OR UNIX) include_directories(/ usr / local / Cellar / libomp /
+                                               15.0.2 / include)
+          include_directories(/ usr / local / Cellar / libomp / 15.0.7 /
+                              include) include_directories(/ usr / local /
+                                                           Cellar / libomp)
+            include_directories(/ usr / local / opt / libomp /
+                                include) include_directories(/ usr / local /
+                                                             opt / libomp / lib)
+              include_directories(/ usr / local / opt /
+                                  libomp) include_directories(/ usr / local /
+                                                              opt) endif()
 
-if(WIN32)
-    add_executable(BanditPAM getopt.cpp main.cpp )
-elseif(APPLE OR UNIX)
-    add_executable(BanditPAM main.cpp )
-endif()
-add_library(
-        BanditPAM_LIB algorithms/kmedoids_algorithm.cpp
-        algorithms/pam.cpp
-        algorithms/banditpam.cpp
-        algorithms/banditpam_orig.cpp
-        algorithms/fastpam1.cpp)
+                if (WIN32) add_executable(BanditPAM getopt.cpp main.cpp) elseif(
+                  APPLE OR UNIX) add_executable(BanditPAM main.cpp) endif()
+                  add_library(BanditPAM_LIB algorithms /
+                              kmedoids_algorithm.cpp algorithms /
+                              pam.cpp algorithms / banditpam.cpp algorithms /
+                              banditpam_orig.cpp algorithms / fastpam1.cpp)
 
-target_link_libraries(BanditPAM PUBLIC BanditPAM_LIB)
+                    target_link_libraries(BanditPAM PUBLIC BanditPAM_LIB)
 
-if(WIN32)
-    target_link_directories(BanditPAM PUBLIC ${OPENBLAS_dir})
-    target_link_libraries(BanditPAM_LIB libopenblas)
-endif()
+                      if (WIN32) target_link_directories(BanditPAM PUBLIC ${
+                        OPENBLAS_dir})
+                        target_link_libraries(BanditPAM_LIB libopenblas) endif()
 
-if(APPLE OR UNIX)
-    find_package(Armadillo REQUIRED)
-    include_directories(${ARMADILLO_INCLUDE_DIRS})
-    target_link_libraries(BanditPAM PUBLIC ${ARMADILLO_LIBRARIES})
-endif()
+                          if (APPLE OR UNIX) find_package(Armadillo REQUIRED)
+                            include_directories(${ARMADILLO_INCLUDE_DIRS})
+                              target_link_libraries(BanditPAM PUBLIC ${
+                                ARMADILLO_LIBRARIES}) endif()
 
-if(WIN32)
-    # Windows uses backslashes for paths while Unix systems use forward slashes
-    string(REPLACE "/" "\\"  OPENBLAS_dir_win ${OPENBLAS_dir})
-    # Copy all DLLs from OPENBLAS_dir_win to the output directory
-    add_custom_command(TARGET BanditPAM_LIB POST_BUILD
-                COMMAND copy ${OPENBLAS_dir_win}\\*.dll $(OutDir))
-endif()
+                                if (WIN32)
+#Windows uses backslashes for paths while Unix systems use forward slashes
+                                  string(REPLACE
+                                         "/"
+                                         "\\" OPENBLAS_dir_win ${OPENBLAS_dir})
+#Copy all DLLs from OPENBLAS_dir_win to the output directory
+                                    add_custom_command(
+                                      TARGET BanditPAM_LIB POST_BUILD COMMAND
+                                        copy $ {
+                                          OPENBLAS_dir_win
+                                        }\\*.dll $(OutDir)) endif()

--- a/src/algorithms/banditpam.cpp
+++ b/src/algorithms/banditpam.cpp
@@ -87,8 +87,8 @@ arma::frowvec BanditPAM::buildSigma(
 #pragma omp parallel for if (this->parallelize)
   for (size_t i = 0; i < N; i++) {
     for (size_t j = 0; j < batchSize; j++) {
-      float cost =
-        KMedoids::cachedLoss(data, distMat, i, referencePoints(j), AlgorithmStep::MISC);
+      float cost = KMedoids::cachedLoss(data, distMat, i, referencePoints(j),
+                                        AlgorithmStep::MISC);
       if (useAbsolute) {
         sample(j) = cost;
       } else {
@@ -136,9 +136,8 @@ arma::frowvec BanditPAM::buildTarget(
   for (size_t i = 0; i < target->n_rows; i++) {
     float total = 0;
     for (size_t j = 0; j < referencePoints.n_rows; j++) {
-      float cost =
-        KMedoids::cachedLoss(data, distMat, (*target)(i), referencePoints(j),
-                             AlgorithmStep::BUILD);
+      float cost = KMedoids::cachedLoss(
+        data, distMat, (*target)(i), referencePoints(j), AlgorithmStep::BUILD);
       if (useAbsolute) {
         total += cost;
       } else {
@@ -286,8 +285,8 @@ arma::fmat BanditPAM::swapSigma(
 
     // calculate change in loss for some subset of the data
     for (size_t j = 0; j < batchSize; j++) {
-      float cost =
-        KMedoids::cachedLoss(data, distMat, n, referencePoints(j), AlgorithmStep::MISC);
+      float cost = KMedoids::cachedLoss(data, distMat, n, referencePoints(j),
+                                        AlgorithmStep::MISC);
 
       if (k == (*assignments)(referencePoints(j))) {
         if (cost < (*secondBestDistances)(referencePoints(j))) {
@@ -365,9 +364,8 @@ arma::fmat BanditPAM::swapTarget(
   for (size_t i = 0; i < T; i++) {
     // TODO(@motiwari): pragma omp parallel for?
     for (size_t j = 0; j < tmpBatchSize; j++) {
-      float cost =
-        KMedoids::cachedLoss(data, distMat, (*targets)(i), referencePoints(j),
-                             AlgorithmStep::SWAP);
+      float cost = KMedoids::cachedLoss(
+        data, distMat, (*targets)(i), referencePoints(j), AlgorithmStep::SWAP);
       size_t k = (*assignments)(referencePoints(j));
       if (cost < (*bestDistances)(referencePoints(j))) {
         // We might be able to change this to

--- a/src/algorithms/banditpam_orig.cpp
+++ b/src/algorithms/banditpam_orig.cpp
@@ -89,8 +89,8 @@ arma::frowvec BanditPAM_orig::buildSigma(
   for (size_t i = 0; i < N; i++) {
     for (size_t j = 0; j < batchSize; j++) {
       // 0 for MISC
-      float cost =
-        KMedoids::cachedLoss(data, distMat, i, referencePoints(j), km::AlgorithmStep::MISC);
+      float cost = KMedoids::cachedLoss(data, distMat, i, referencePoints(j),
+                                        km::AlgorithmStep::MISC);
       if (useAbsolute) {
         sample(j) = cost;
       } else {
@@ -138,9 +138,8 @@ arma::frowvec BanditPAM_orig::buildTarget(
   for (size_t i = 0; i < target->n_rows; i++) {
     float total = 0;
     for (size_t j = 0; j < referencePoints.n_rows; j++) {
-      float cost =
-        KMedoids::cachedLoss(data, distMat, (*target)(i), referencePoints(j),
-                             AlgorithmStep::BUILD);
+      float cost = KMedoids::cachedLoss(
+        data, distMat, (*target)(i), referencePoints(j), AlgorithmStep::BUILD);
       if (useAbsolute) {
         total += cost;
       } else {
@@ -288,8 +287,8 @@ arma::fmat BanditPAM_orig::swapSigma(
 
     // calculate change in loss for some subset of the data
     for (size_t j = 0; j < batchSize; j++) {
-      float cost =
-        KMedoids::cachedLoss(data, distMat, n, referencePoints(j), AlgorithmStep::MISC);
+      float cost = KMedoids::cachedLoss(data, distMat, n, referencePoints(j),
+                                        AlgorithmStep::MISC);
 
       if (k == (*assignments)(referencePoints(j))) {
         if (cost < (*secondBestDistances)(referencePoints(j))) {
@@ -353,8 +352,8 @@ arma::fvec BanditPAM_orig::swapTarget(
     size_t k = (*targets)(i) % medoidIndices->n_cols;
     // calculate total loss for some subset of the data
     for (size_t j = 0; j < tmpBatchSize; j++) {
-      float cost =
-        KMedoids::cachedLoss(data, distMat, n, referencePoints(j), AlgorithmStep::SWAP);
+      float cost = KMedoids::cachedLoss(data, distMat, n, referencePoints(j),
+                                        AlgorithmStep::SWAP);
       if (k == (*assignments)(referencePoints(j))) {
         if (cost < (*secondBestDistances)(referencePoints(j))) {
           total += cost;

--- a/src/algorithms/kmedoids_algorithm.cpp
+++ b/src/algorithms/kmedoids_algorithm.cpp
@@ -268,8 +268,8 @@ void KMedoids::calcBestDistancesSwap(
     float best = std::numeric_limits<float>::infinity();
     float second = std::numeric_limits<float>::infinity();
     for (size_t k = 0; k < medoidIndices->n_cols; k++) {
-      float cost =
-        KMedoids::cachedLoss(data, distMat, i, (*medoidIndices)(k), AlgorithmStep::MISC);
+      float cost = KMedoids::cachedLoss(data, distMat, i, (*medoidIndices)(k),
+                                        AlgorithmStep::MISC);
       if (cost < best) {
         (*assignments)(i) = k;
         second = best;
@@ -298,9 +298,8 @@ float KMedoids::calcLoss(
   for (size_t i = 0; i < data.n_cols; i++) {
     float cost = std::numeric_limits<float>::infinity();
     for (size_t k = 0; k < nMedoids; k++) {
-      float currCost =
-        KMedoids::cachedLoss(data, distMat, i, (*medoidIndices)(k),
-                             AlgorithmStep::MISC);
+      float currCost = KMedoids::cachedLoss(
+        data, distMat, i, (*medoidIndices)(k), AlgorithmStep::MISC);
       if (currCost < cost) {
         cost = currCost;
       }
@@ -324,7 +323,8 @@ float KMedoids::cachedLoss(
   } else if (step == AlgorithmStep::SWAP) {
     numSwapDistanceComputations++;
   } else {
-    throw std::invalid_argument("Unknown AlgorithmStep in KMedoids::cachedLoss");
+    throw std::invalid_argument(
+      "Unknown AlgorithmStep in KMedoids::cachedLoss");
   }
 
   if (this->useDistMat) {
@@ -388,15 +388,16 @@ float KMedoids::cos(const arma::fmat &data, const size_t i,
 }
 
 float KMedoids::clippedCos(const arma::fmat &data, const size_t i,
-                    const size_t j) const {
+                           const size_t j) const {
   // Calculate the cosine distance
   float cos = (arma::dot(data.col(i), data.col(j)) /
-                           (arma::norm(data.col(i)) * arma::norm(data.col(j))));
-  
+               (arma::norm(data.col(i)) * arma::norm(data.col(j))));
+
   if (cos < 0.3) {
-    return 1; // Cosine distance is too large, so we consider the similarity as zero
+    return 1;  // Cosine distance is too large, so we consider the similarity as
+               // zero
   } else {
-    return 1 - cos; // Cosine distance is within the threshold, return it
+    return 1 - cos;  // Cosine distance is within the threshold, return it
   }
 }
 
@@ -405,26 +406,29 @@ float KMedoids::manhattan(const arma::fmat &data, const size_t i,
   return arma::accu(arma::abs(data.col(i) - data.col(j)));
 }
 
-float KMedoids::pearson(const arma::fmat &data, const size_t i, const size_t j) const {
-  const arma::fvec& xi = data.col(i);
-  const arma::fvec& xj = data.col(j);
+float KMedoids::pearson(const arma::fmat &data, const size_t i,
+                        const size_t j) const {
+  const arma::fvec &xi = data.col(i);
+  const arma::fvec &xj = data.col(j);
   float mean_i = arma::mean(xi);
   float mean_j = arma::mean(xj);
   float numerator = arma::dot(xi - mean_i, xj - mean_j);
-  float denominator = std::sqrt(arma::dot(xi - mean_i, xi - mean_i) * arma::dot(xj - mean_j, xj - mean_j));
+  float denominator = std::sqrt(arma::dot(xi - mean_i, xi - mean_i) *
+                                arma::dot(xj - mean_j, xj - mean_j));
   return 1 - numerator / denominator;
 }
 
-arma::fvec KMedoids::rank(const arma::fvec& vec) const {
+arma::fvec KMedoids::rank(const arma::fvec &vec) const {
   arma::uvec sortedIndices = arma::sort_index(vec);
   arma::fvec ranks(vec.size());
   for (size_t i = 0; i < vec.size(); ++i) {
-      ranks(sortedIndices(i)) = i + 1;
+    ranks(sortedIndices(i)) = i + 1;
   }
   return ranks;
 }
 
-float KMedoids::spearman(const arma::fmat &data, const size_t i, const size_t j) const {
+float KMedoids::spearman(const arma::fmat &data, const size_t i,
+                         const size_t j) const {
   arma::fvec rank_i = rank(data.col(i));
   arma::fvec rank_j = rank(data.col(j));
   return pearson(arma::join_rows(rank_i, rank_j), 0, 1);

--- a/src/algorithms/kmedoids_algorithm.cpp
+++ b/src/algorithms/kmedoids_algorithm.cpp
@@ -316,7 +316,7 @@ float KMedoids::cachedLoss(
   const arma::fmat &data,
   std::optional<std::reference_wrapper<const arma::fmat>> distMat,
   const size_t i, const size_t j, AlgorithmStep step,
-  const bool useCacheFunctionOverride = true) {
+  const bool useCacheFunctionOverride) {
   if (step == AlgorithmStep::MISC) {
     numMiscDistanceComputations++;
   } else if (step == AlgorithmStep::BUILD) {

--- a/src/algorithms/kmedoids_algorithm.cpp
+++ b/src/algorithms/kmedoids_algorithm.cpp
@@ -18,11 +18,6 @@
 #include "banditpam_orig.hpp"
 
 namespace km {
-enum class AlgorithmStep {
-  MISC,
-  BUILD,
-  SWAP
-};
 
 // NOTE: The order of arguments in this constructor must match that of the
 // arguments in kmedoids_pywrapper.cpp, otherwise undefined behavior can

--- a/src/python_bindings/loss_fn_python.cpp
+++ b/src/python_bindings/loss_fn_python.cpp
@@ -34,4 +34,4 @@ std::string km::KMedoidsWrapper::getLossFn() const {
       throw std::invalid_argument("Error: Loss Function Undefined!");
   }
 }
-}  // namespace km 
+}  // namespace km


### PR DESCRIPTION
BanditPAM v6.0.2 contains several bugfixes:

- Gets all GHA to work correctly
- Fixes the R Bindings
- Bumps the MacOS deployment target to 15
- Contains style cleanups
- Pins armadillo to 14.6.3 on Mac