### PR TITLE
Include R_package in style checks (fixes #240)

### DIFF
--- a/.github/workflows/run_style_checks.yml
+++ b/.github/workflows/run_style_checks.yml
@@ -45,7 +45,7 @@ jobs:
           style: file
           tidy-checks: '-*'  # disable clang-tidy checks
           version: 16
-          ignore: R_package  # TODO: remove this as part of #240
+          ignore: headers/carma|headers/carma-stable  # Ignore third-party code only
           files-changed-only: false
 
       - name: Exit if necessary


### PR DESCRIPTION
<h1>Description: Fixes #240. This Pull Request updates the GitHub Actions workflow </h1>
<h3>run_style_checks.yml
 to include the R_package directory in automated style checks. Previously, this directory was fully ignored, allowing potential style deviations. I have updated the configuration to only exclude third-party code (specifically headers/carma and headers/carma-stable), ensuring that all BanditPAM C++ source code, including R bindings, now adheres to the project's formatting standards (Google Style via clang-format).</h3>