### PR TITLE
feat: added support for getTotalSwapTime and getTimePerSwap

### DIFF
--- a/R_package/banditpam/src/banditpam.cpp
+++ b/R_package/banditpam/src/banditpam.cpp
@@ -7,6 +7,7 @@
 
 #include "banditpam.hpp"
 
+#include <chrono>
 #include <unordered_map>
 #include <cmath>
 
@@ -427,6 +428,7 @@ void BanditPAM::swap(
 
   // continue making swaps while loss is decreasing
   while (swapPerformed && steps < maxIter) {
+    const auto swap_step_start = std::chrono::steady_clock::now();
     steps++;
     permutationIdx = 0;
 
@@ -546,6 +548,11 @@ void BanditPAM::swap(
       &secondBestDistances,
       assignments,
       swapPerformed);
+    const auto swap_step_end = std::chrono::steady_clock::now();
+    totalSwapTime += std::chrono::duration_cast<std::chrono::milliseconds>(
+                        swap_step_end - swap_step_start)
+                        .count();
+    swapTimingIterations++;
   }
 }
 }  // namespace km

--- a/R_package/banditpam/src/banditpam_orig.cpp
+++ b/R_package/banditpam/src/banditpam_orig.cpp
@@ -7,6 +7,7 @@
 
 #include "banditpam_orig.hpp"
 
+#include <chrono>
 #include <unordered_map>
 #include <cmath>
 
@@ -414,6 +415,7 @@ void BanditPAM_orig::swap(
 
   // continue making swaps while loss is decreasing
   while (swapPerformed && steps < maxIter) {
+    const auto swap_step_start = std::chrono::steady_clock::now();
     steps++;
     permutationIdx = 0;
 
@@ -504,6 +506,11 @@ void BanditPAM_orig::swap(
       &secondBestDistances,
       assignments,
       swapPerformed);
+    const auto swap_step_end = std::chrono::steady_clock::now();
+    totalSwapTime += std::chrono::duration_cast<std::chrono::milliseconds>(
+                        swap_step_end - swap_step_start)
+                        .count();
+    swapTimingIterations++;
   }
 }
 }  // namespace km

--- a/R_package/banditpam/src/fastpam1.cpp
+++ b/R_package/banditpam/src/fastpam1.cpp
@@ -12,6 +12,7 @@
 
 #include "fastpam1.hpp"
 
+#include <chrono>
 #include <unordered_map>
 
 namespace km {
@@ -120,6 +121,7 @@ void FastPAM1::swapFastPAM1(
   banditpam_float dij = 0;
 
   while (swapPerformed && iter < maxIter) {
+    const auto swap_step_start = std::chrono::steady_clock::now();
     iter++;
     // TODO(@motiwari): pragma omp parallel for?
     for (size_t i = 0; i < data.n_cols; i++) {
@@ -180,6 +182,11 @@ void FastPAM1::swapFastPAM1(
     } else {
       swapPerformed = false;
     }
+    const auto swap_step_end = std::chrono::steady_clock::now();
+    totalSwapTime += std::chrono::duration_cast<std::chrono::milliseconds>(
+                        swap_step_end - swap_step_start)
+                        .count();
+    swapTimingIterations++;
   }
 }
 }  // namespace km

--- a/R_package/banditpam/src/kmedoids_algorithm.cpp
+++ b/R_package/banditpam/src/kmedoids_algorithm.cpp
@@ -58,6 +58,8 @@ void KMedoids::fit(
   numCacheWrites = 0;
   numCacheHits = 0;
   numCacheMisses = 0;
+  totalSwapTime = 0;
+  swapTimingIterations = 0;
 
   if (distMat) {  // User has provided a distance matrix
     if (distMat.value().get().n_cols != distMat.value().get().n_rows) {
@@ -257,7 +259,11 @@ size_t KMedoids::getTotalSwapTime() const {
 }
 
 banditpam_float KMedoids::getTimePerSwap() const {
-  return totalSwapTime / steps;
+  if (swapTimingIterations == 0) {
+    return 0;
+  }
+  return static_cast<banditpam_float>(totalSwapTime) /
+         static_cast<banditpam_float>(swapTimingIterations);
 }
 
 void KMedoids::setLossFn(std::string loss) {

--- a/R_package/banditpam/src/kmedoids_algorithm.hpp
+++ b/R_package/banditpam/src/kmedoids_algorithm.hpp
@@ -591,8 +591,11 @@ class KMedoids {
   /// need to compute. For debugging only.
   size_t numCacheMisses = 0;
 
-  /// The number of milliseconds taken per swap step, on average
+  /// Total milliseconds spent in timed swap iterations (see swapTimingIterations)
   size_t totalSwapTime = 0;
+
+  /// Number of timed swap iterations that contributed to totalSwapTime
+  size_t swapTimingIterations = 0;
 };
 }  // namespace km
 #endif  // HEADERS_ALGORITHMS_KMEDOIDS_ALGORITHM_HPP_

--- a/R_package/banditpam/src/pam.cpp
+++ b/R_package/banditpam/src/pam.cpp
@@ -10,6 +10,7 @@
 
 #include "pam.hpp"
 
+#include <chrono>
 #include <unordered_map>
 
 namespace km {
@@ -27,7 +28,13 @@ void PAM::fitPAM(
   bool medoidChange = true;
   while (i < maxIter && medoidChange) {
     auto previous(medoidIndices);
+    const auto swap_step_start = std::chrono::steady_clock::now();
     PAM::swapPAM(data, distMat, &medoidIndices, &assignments);
+    const auto swap_step_end = std::chrono::steady_clock::now();
+    totalSwapTime += std::chrono::duration_cast<std::chrono::milliseconds>(
+                        swap_step_end - swap_step_start)
+                        .count();
+    swapTimingIterations++;
     medoidChange = arma::any(medoidIndices != previous);
     i++;
   }

--- a/headers/algorithms/kmedoids_algorithm.hpp
+++ b/headers/algorithms/kmedoids_algorithm.hpp
@@ -622,8 +622,11 @@ class KMedoids {
   /// need to compute. For debugging only.
   size_t numCacheMisses = 0;
 
-  /// The number of milliseconds taken per swap step, on average
+  /// Total milliseconds spent in timed swap iterations (see swapTimingIterations)
   size_t totalSwapTime = 0;
+
+  /// Number of timed swap iterations that contributed to totalSwapTime
+  size_t swapTimingIterations = 0;
 };
 }  // namespace km
 #endif  // HEADERS_ALGORITHMS_KMEDOIDS_ALGORITHM_HPP_

--- a/src/algorithms/banditpam.cpp
+++ b/src/algorithms/banditpam.cpp
@@ -8,6 +8,7 @@
 #include "banditpam.hpp"
 
 #include <armadillo>
+#include <chrono>
 #include <unordered_map>
 #include <cmath>
 #include <vector>
@@ -415,6 +416,7 @@ void BanditPAM::swap(
 
   // continue making swaps while loss is decreasing
   while (swapPerformed && steps < maxIter) {
+    const auto swap_step_start = std::chrono::steady_clock::now();
     steps++;
     permutationIdx = 0;
 
@@ -516,6 +518,11 @@ void BanditPAM::swap(
 
     calcBestDistancesSwap(data, distMat, medoidIndices, &bestDistances,
                           &secondBestDistances, assignments, swapPerformed);
+    const auto swap_step_end = std::chrono::steady_clock::now();
+    totalSwapTime += std::chrono::duration_cast<std::chrono::milliseconds>(
+                        swap_step_end - swap_step_start)
+                        .count();
+    swapTimingIterations++;
   }
 }
 }  // namespace km

--- a/src/algorithms/banditpam_orig.cpp
+++ b/src/algorithms/banditpam_orig.cpp
@@ -8,6 +8,7 @@
 #include "banditpam_orig.hpp"
 
 #include <armadillo>
+#include <chrono>
 #include <unordered_map>
 #include <cmath>
 #include <vector>
@@ -403,6 +404,7 @@ void BanditPAM_orig::swap(
 
   // continue making swaps while loss is decreasing
   while (swapPerformed && steps < maxIter) {
+    const auto swap_step_start = std::chrono::steady_clock::now();
     steps++;
     permutationIdx = 0;
 
@@ -475,6 +477,11 @@ void BanditPAM_orig::swap(
     }
     calcBestDistancesSwap(data, distMat, medoidIndices, &bestDistances,
                           &secondBestDistances, assignments, swapPerformed);
+    const auto swap_step_end = std::chrono::steady_clock::now();
+    totalSwapTime += std::chrono::duration_cast<std::chrono::milliseconds>(
+                        swap_step_end - swap_step_start)
+                        .count();
+    swapTimingIterations++;
   }
 }
 }  // namespace km

--- a/src/algorithms/fastpam1.cpp
+++ b/src/algorithms/fastpam1.cpp
@@ -14,6 +14,7 @@
 #include "fastpam1.hpp"
 
 #include <armadillo>
+#include <chrono>
 #include <unordered_map>
 
 namespace km {
@@ -118,6 +119,7 @@ void FastPAM1::swapFastPAM1(
   float dij = 0;
 
   while (swapPerformed && iter < maxIter) {
+    const auto swap_step_start = std::chrono::steady_clock::now();
     bestChange = 0;
     deltaTD.zeros();
     iter++;
@@ -188,6 +190,11 @@ void FastPAM1::swapFastPAM1(
     } else {
       swapPerformed = false;
     }
+    const auto swap_step_end = std::chrono::steady_clock::now();
+    totalSwapTime += std::chrono::duration_cast<std::chrono::milliseconds>(
+                        swap_step_end - swap_step_start)
+                        .count();
+    swapTimingIterations++;
   }
 }
 }  // namespace km

--- a/src/algorithms/kmedoids_algorithm.cpp
+++ b/src/algorithms/kmedoids_algorithm.cpp
@@ -53,6 +53,8 @@ void KMedoids::fit(
   numCacheWrites = 0;
   numCacheHits = 0;
   numCacheMisses = 0;
+  totalSwapTime = 0;
+  swapTimingIterations = 0;
 
   if (distMat) {  // User has provided a distance matrix
     if (distMat.value().get().n_cols != distMat.value().get().n_rows) {
@@ -208,7 +210,13 @@ size_t KMedoids::getCacheMisses() const { return numCacheMisses; }
 
 size_t KMedoids::getTotalSwapTime() const { return totalSwapTime; }
 
-float KMedoids::getTimePerSwap() const { return totalSwapTime / steps; }
+float KMedoids::getTimePerSwap() const {
+  if (swapTimingIterations == 0) {
+    return 0.0f;
+  }
+  return static_cast<float>(totalSwapTime) /
+         static_cast<float>(swapTimingIterations);
+}
 
 void KMedoids::setLossFn(std::string loss) {
   // TODO(@motiwari): On setting this, clear the

--- a/src/algorithms/pam.cpp
+++ b/src/algorithms/pam.cpp
@@ -12,6 +12,7 @@
 #include "pam.hpp"
 
 #include <armadillo>
+#include <chrono>
 #include <unordered_map>
 
 namespace km {
@@ -30,7 +31,13 @@ void PAM::fitPAM(
   while (i < maxIter && medoidChange) {
     auto previous(medoidIndices);
     if (nMedoids > 1) {
+      const auto swap_step_start = std::chrono::steady_clock::now();
       PAM::swapPAM(data, distMat, &medoidIndices, &assignments);
+      const auto swap_step_end = std::chrono::steady_clock::now();
+      totalSwapTime += std::chrono::duration_cast<std::chrono::milliseconds>(
+                          swap_step_end - swap_step_start)
+                          .count();
+      swapTimingIterations++;
     }
 
     medoidChange = arma::any(medoidIndices != previous);

--- a/tests/test_smaller.py
+++ b/tests/test_smaller.py
@@ -1,3 +1,4 @@
+import math
 import unittest
 import pandas as pd
 import numpy as np
@@ -133,6 +134,56 @@ class SmallerTests(unittest.TestCase):
 
         # error on trying to fit on empy
         self.assertRaises(ValueError, kmed.fit, np.array([]), "L2")
+
+    def test_swap_timing_stats(self):
+        """
+        After fit(), total_swap_time (ms) and time_per_swap are consistent.
+
+        For BanditPAM, BanditPAM_orig, and PAM, each SWAP outer iteration is
+        timed once and matches ``steps``, so time_per_swap * steps equals
+        total_swap_time (ms).
+
+        FastPAM1 counts ``steps`` as outer refinement iterations while timing
+        multiple inner swaps per call; we only assert types and non-negativity.
+        """
+        data = self.small_mnist
+        for algo in ("BanditPAM", "BanditPAM_orig", "FastPAM1", "PAM"):
+            with self.subTest(algorithm=algo):
+                kmed = KMedoids(n_medoids=5, algorithm=algo, max_iter=100)
+                kmed.seed = 0
+                kmed.fit(data, "L2")
+                total_ms = kmed.total_swap_time
+                tps = kmed.time_per_swap
+                n_swaps = kmed.steps
+                self.assertIsInstance(total_ms, int)
+                self.assertIsInstance(tps, float)
+                self.assertGreaterEqual(total_ms, 0)
+                self.assertGreaterEqual(tps, 0.0)
+                if total_ms == 0:
+                    self.assertEqual(tps, 0.0)
+
+                if algo == "FastPAM1":
+                    continue
+
+                if n_swaps == 0:
+                    self.assertEqual(total_ms, 0)
+                    self.assertEqual(tps, 0.0)
+                    continue
+
+                reconstructed = tps * float(n_swaps)
+                ok = math.isclose(
+                    reconstructed,
+                    float(total_ms),
+                    rel_tol=1e-5,
+                    abs_tol=1e-4,
+                )
+                self.assertTrue(
+                    ok,
+                    msg=(
+                        f"{algo}: time_per_swap * steps = {reconstructed}, "
+                        f"total_swap_time = {total_ms}, steps = {n_swaps}"
+                    ),
+                )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Instruments swap phases so `getTotalSwapTime()` (total milliseconds) and `getTimePerSwap()` (average ms per timed swap iteration) reflect measured wall time.
`getTimePerSwap()` now divides by the number of timed swap iterations (`swapTimingIterations`), not the generic swap steps counter where those differ.
Adds a Python regression test on the MNIST_100 subset used elsewhere in the smaller test suite.

---

## Motivation

* `totalSwapTime` was not updated inside the swap loops.
* `getTimePerSwap()` used `totalSwapTime / steps`, which does not match “average time per timed swap iteration” when `steps` counts something other than timed iterations.
* Notably in **FastPAM1**, where `steps` is outer-loop iterations while timing sums inner `swapFastPAM1` iterations.

---

## Implementation

### KMedoids

* Introduces `swapTimingIterations` counter.
* `totalSwapTime` reset along with `swapTimingIterations` at `fit()` start.
* `getTimePerSwap()`:

  * Returns `0` when there are no timed iterations.
  * Otherwise returns `totalSwapTime / swapTimingIterations`.
* Changes mirrored in `R_package/banditpam/src/` headers and sources.

### Timing

Each timed swap loop uses:

* `std::chrono::steady_clock`
* `std::chrono::duration_cast<std::chrono::milliseconds>`

Applied in:

* `BanditPAM`
* `BanditPAM_orig`
* `FastPAM1::swapFastPAM1`
* `PAM::fitPAM` (when `nMedoids > 1` in the main tree)

---

## Tests

**File:** `tests/test_smaller.py`

### `test_swap_timing_stats`

* Fits `k = 5` on `small_mnist` (`data/MNIST_100.csv`) for:

  * `BanditPAM`
  * `BanditPAM_orig`
  * `FastPAM1`
  * `PAM`

### Assertions

* Types are correct
* Values are non-negative
* `time_per_swap == 0` when `total_swap_time == 0`

### Additional Checks

* For **BanditPAM**, **BanditPAM_orig**, and **PAM**:

  * `time_per_swap * steps ≈ total_swap_time`
  * (`steps` matches timed iterations)

* For **FastPAM1**:

  * Skip identity check
  * (`steps` does not match inner timed swap count)

---

## How to Verify

```bash
pytest tests/test_smaller.py::SmallerTests::test_swap_timing_stats -v
```
